### PR TITLE
Enhance the scan status and error reporting from EMA

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/plugin/ScanDataPublisherDelegateImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/plugin/ScanDataPublisherDelegateImpl.java
@@ -16,6 +16,6 @@ public class ScanDataPublisherDelegateImpl extends MessagingServiceRouteDelegate
     public List<RouteBundle> generateRouteList(List<RouteBundle> destinations, List<RouteBundle> recipients,
                                                String scanType, String messagingServiceId) {
         return List.of(createRouteBundle(destinations, recipients, scanType, messagingServiceId,
-                "seda:eventPortal", false));
+                "direct:eventPortal", false));
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/EmptyScanEntityProcessorImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/EmptyScanEntityProcessorImpl.java
@@ -1,0 +1,83 @@
+package com.solace.maas.ep.event.management.agent.processor;
+
+import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanRecipientHierarchyEntity;
+import com.solace.maas.ep.event.management.agent.repository.scan.ScanRecipientHierarchyRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
+import org.springframework.stereotype.Component;
+
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class EmptyScanEntityProcessorImpl extends EmptyScanEntityProcessor {
+    private final ProducerTemplate producerTemplate;
+
+    private final ScanRecipientHierarchyRepository scanRecipientHierarchyRepository;
+
+    public EmptyScanEntityProcessorImpl(ProducerTemplate producerTemplate,
+                                        ScanRecipientHierarchyRepository scanRecipientHierarchyRepository) {
+        this.producerTemplate = producerTemplate;
+        this.scanRecipientHierarchyRepository = scanRecipientHierarchyRepository;
+    }
+
+    @Transactional
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        Map<String, Object> properties = exchange.getIn().getHeaders();
+
+        String messagingServiceId = (String) properties.get(RouteConstants.MESSAGING_SERVICE_ID);
+        String scanId = (String) properties.get(RouteConstants.SCAN_ID);
+        String scanType = (String) properties.get(RouteConstants.SCAN_TYPE);
+
+        log.info("Scan request [{}]: Encountered an empty scan type [{}].", scanId, scanType);
+
+        sendCompleteStatusForScanType(scanId, messagingServiceId, scanType);
+
+        log.info("Scan request [{}]: The status of [{}]" + " is: [{}].", scanId, scanType, ScanStatus.COMPLETE);
+
+        checkScanTypeDescendent(scanId, messagingServiceId, scanType);
+    }
+
+    private void checkScanTypeDescendent(String scanId, String messagingServiceId, String scanType) {
+        List<ScanRecipientHierarchyEntity> scanRecipientHierarchyEntities =
+                scanRecipientHierarchyRepository.findScanRecipientHierarchyEntitiesByScanId(scanId);
+
+        Map<String, String> store = scanRecipientHierarchyEntities.stream()
+                .map(ScanRecipientHierarchyEntity::getStore)
+                .findFirst().orElseThrow();
+
+        List<String> emptyScanTypesHierarchyPaths = new ArrayList<>(store.values());
+
+        emptyScanTypesHierarchyPaths.forEach(emptyScanTypesPath -> {
+            List<String> emptyScanTypes = Arrays.asList(emptyScanTypesPath.split(","));
+
+            if (emptyScanTypes.contains(scanType)) {
+                int parentScanTypeIndex = emptyScanTypes.indexOf(scanType);
+                List<String> childScanTypes = emptyScanTypes.subList(parentScanTypeIndex + 1, emptyScanTypes.size());
+
+                childScanTypes.forEach(childScanType -> {
+                    log.info("Scan request [{}]: Encountered an empty scan type [{}].", scanId, childScanType);
+                    sendCompleteStatusForScanType(scanId, messagingServiceId, childScanType);
+                    log.info("Scan request [{}]: The status of [{}]" + " is: [{}].", scanId, childScanType, ScanStatus.COMPLETE);
+                });
+            }
+        });
+    }
+
+    public void sendCompleteStatusForScanType(String scanId, String messagingServiceId, String scanType) {
+        producerTemplate.send("direct:processScanStatusAsComplete?block=false&failIfNoConsumers=false", exchange -> {
+            exchange.getIn().setHeader(RouteConstants.SCAN_ID, scanId);
+            exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, messagingServiceId);
+            exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, scanType);
+        });
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/RouteCompleteProcessorImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/RouteCompleteProcessorImpl.java
@@ -2,7 +2,6 @@ package com.solace.maas.ep.event.management.agent.processor;
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
-import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatusType;
 import com.solace.maas.ep.event.management.agent.plugin.processor.RouteCompleteProcessor;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanStatusEntity;
 import com.solace.maas.ep.event.management.agent.repository.scan.ScanStatusRepository;
@@ -22,7 +21,6 @@ public class RouteCompleteProcessorImpl extends RouteCompleteProcessor {
     @Override
     public void process(Exchange exchange) throws Exception {
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.COMPLETE);
-        exchange.getIn().setHeader(RouteConstants.SCAN_STATUS_TYPE, ScanStatusType.PER_ROUTE);
 
         String scanId = (String) exchange.getIn().getHeader(RouteConstants.SCAN_ID);
         String scanType = (String) exchange.getIn().getHeader(RouteConstants.SCAN_TYPE);
@@ -34,8 +32,6 @@ public class RouteCompleteProcessorImpl extends RouteCompleteProcessor {
                 .build();
 
         save(scanStatusEntity);
-
-        log.info("Scan request [{}]: The status of [{}] is: [{}].", scanId, scanType, ScanStatus.COMPLETE.name());
     }
 
     protected ScanStatusEntity save(ScanStatusEntity scanStatusEntity) {

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/RouteCompleteProcessorImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/RouteCompleteProcessorImpl.java
@@ -9,6 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Slf4j
 @Component
 public class RouteCompleteProcessorImpl extends RouteCompleteProcessor {
@@ -23,7 +25,15 @@ public class RouteCompleteProcessorImpl extends RouteCompleteProcessor {
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.COMPLETE);
 
         String scanId = (String) exchange.getIn().getHeader(RouteConstants.SCAN_ID);
-        String scanType = (String) exchange.getIn().getHeader(RouteConstants.SCAN_TYPE);
+
+        String scanType;
+
+        if (exchange.getIn().getHeader(RouteConstants.SCAN_TYPE) instanceof List<?>) {
+            scanType = (String) exchange.getIn().getBody();
+            exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, scanType);
+        } else {
+            scanType = (String) exchange.getIn().getHeader(RouteConstants.SCAN_TYPE);
+        }
 
         ScanStatusEntity scanStatusEntity = ScanStatusEntity.builder()
                 .scanId(scanId)

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportOverAllStatusProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportOverAllStatusProcessor.java
@@ -4,6 +4,7 @@ import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants
 import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
 import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDetailsBO;
 import lombok.extern.slf4j.Slf4j;
+import net.logstash.logback.encoder.org.apache.commons.lang3.StringUtils;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -24,6 +25,6 @@ public class ScanDataImportOverAllStatusProcessor implements Processor {
         List<String> scanTypes = files.stream().map(MetaInfFileDetailsBO::getDataEntityType).collect(Collectors.toUnmodifiableList());
 
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.IN_PROGRESS);
-        exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, scanTypes);
+        exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, StringUtils.join(scanTypes,","));
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportOverAllStatusProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportOverAllStatusProcessor.java
@@ -2,7 +2,6 @@ package com.solace.maas.ep.event.management.agent.processor;
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
-import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatusType;
 import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDetailsBO;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
@@ -13,6 +12,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@SuppressWarnings("unchecked")
 @Slf4j
 @Component
 @ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
@@ -24,7 +24,6 @@ public class ScanDataImportOverAllStatusProcessor implements Processor {
         List<String> scanTypes = files.stream().map(MetaInfFileDetailsBO::getDataEntityType).collect(Collectors.toUnmodifiableList());
 
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.IN_PROGRESS);
-        exchange.getIn().setHeader(RouteConstants.SCAN_STATUS_TYPE, ScanStatusType.OVERALL);
         exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, scanTypes);
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportStatusProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportStatusProcessor.java
@@ -2,7 +2,6 @@ package com.solace.maas.ep.event.management.agent.processor;
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
-import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatusType;
 import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDetailsBO;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
@@ -20,7 +19,6 @@ public class ScanDataImportStatusProcessor implements Processor {
         String scanType = fileName.getDataEntityType();
 
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.IN_PROGRESS);
-        exchange.getIn().setHeader(RouteConstants.SCAN_STATUS_TYPE, ScanStatusType.PER_ROUTE);
         exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, scanType);
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataProcessor.java
@@ -50,7 +50,7 @@ public class ScanDataProcessor implements Processor {
 
         ScanDataMessage scanDataMessage =
                 new ScanDataMessage(orgId, scanId, scanType, body, Instant.now().toString());
-        log.info("{} sending --> {}", scanType, body);
+
         topicDetails.put("orgId", orgId);
         topicDetails.put("runtimeAgentId", runtimeAgentId);
         topicDetails.put("messagingServiceId", messagingServiceId);
@@ -61,8 +61,7 @@ public class ScanDataProcessor implements Processor {
         try {
             scanDataPublisher.sendScanData(scanDataMessage, topicDetails);
         } catch (Exception e) {
-            throw new ScanDataException("Scan data processor exception: " + e.getMessage(),
-                    Map.of(scanId, List.of(e)), body);
+            throw new ScanDataException("Scan data exception: " + e, Map.of(scanId, List.of(e)), body);
         }
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataProcessor.java
@@ -61,7 +61,7 @@ public class ScanDataProcessor implements Processor {
         try {
             scanDataPublisher.sendScanData(scanDataMessage, topicDetails);
         } catch (Exception e) {
-            throw new ScanDataException("Scan data processor exception: " + e.getCause(),
+            throw new ScanDataException("Scan data processor exception: " + e.getMessage(),
                     Map.of(scanId, List.of(e)), body);
         }
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessor.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +49,8 @@ public class ScanStatusOverAllProcessor implements Processor {
         ScanStatus status = (ScanStatus) properties.get(RouteConstants.SCAN_STATUS);
         String description = (String) properties.get(RouteConstants.SCAN_STATUS_DESC);
 
-        List<String> scanTypes = (List<String>) properties.get(RouteConstants.SCAN_TYPE);
+        String scanType = (String) properties.get(RouteConstants.SCAN_TYPE);
+        List<String> scanTypes = Arrays.asList(scanType.split(","));
 
         topicDetails.put("orgId", orgId);
         topicDetails.put("runtimeAgentId", runtimeAgentId);
@@ -61,8 +63,8 @@ public class ScanStatusOverAllProcessor implements Processor {
         try {
             scanStatusPublisher.sendOverallScanStatus(generalStatusMessage, topicDetails);
         } catch (Exception e) {
-            throw new ScanStatusException("Scan status per route processor exception: " + e.getMessage(),
-                    Map.of(scanId, List.of(e)), "overall status", scanTypes, status);
+            throw new ScanStatusException("Over all status exception: " + e.getMessage(),
+                    Map.of(scanId, List.of(e)), "Overall status", scanTypes, status);
         }
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessor.java
@@ -1,10 +1,11 @@
 package com.solace.maas.ep.event.management.agent.processor;
 
-import com.solace.maas.ep.common.messages.ScanDataMessage;
+import com.solace.maas.ep.common.messages.ScanStatusMessage;
 import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
-import com.solace.maas.ep.event.management.agent.publisher.ScanDataPublisher;
-import com.solace.maas.ep.event.management.agent.route.ep.exceptions.ScanDataException;
+import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
+import com.solace.maas.ep.event.management.agent.publisher.ScanStatusPublisher;
+import com.solace.maas.ep.event.management.agent.route.ep.exceptions.ScanStatusException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
@@ -12,25 +13,26 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@SuppressWarnings("unchecked")
 @Slf4j
 @Component
 @ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
-public class ScanDataProcessor implements Processor {
+public class ScanStatusOverAllProcessor implements Processor {
 
-    private final ScanDataPublisher scanDataPublisher;
     private final String orgId;
     private final String runtimeAgentId;
 
+    private final ScanStatusPublisher scanStatusPublisher;
+
     @Autowired
-    public ScanDataProcessor(ScanDataPublisher scanDataPublisher, EventPortalProperties eventPortalProperties) {
+    public ScanStatusOverAllProcessor(ScanStatusPublisher scanStatusPublisher, EventPortalProperties eventPortalProperties) {
         super();
 
-        this.scanDataPublisher = scanDataPublisher;
+        this.scanStatusPublisher = scanStatusPublisher;
 
         orgId = eventPortalProperties.getOrganizationId();
         runtimeAgentId = eventPortalProperties.getRuntimeAgentId();
@@ -38,31 +40,29 @@ public class ScanDataProcessor implements Processor {
 
     @Override
     public void process(Exchange exchange) throws Exception {
-        Map<String, String> topicDetails = new HashMap<>();
-
+        HashMap<String, String> topicDetails = new HashMap<>();
         Map<String, Object> properties = exchange.getIn().getHeaders();
-        String body = (String) exchange.getIn().getBody();
 
         String messagingServiceId = (String) properties.get(RouteConstants.MESSAGING_SERVICE_ID);
         String scanId = (String) properties.get(RouteConstants.SCAN_ID);
-        String scanType = (String) properties.get(RouteConstants.SCAN_TYPE);
-        Boolean isImportOp = (Boolean) properties.get(RouteConstants.IS_DATA_IMPORT);
+        ScanStatus status = (ScanStatus) properties.get(RouteConstants.SCAN_STATUS);
+        String description = (String) properties.get(RouteConstants.SCAN_STATUS_DESC);
 
-        ScanDataMessage scanDataMessage =
-                new ScanDataMessage(orgId, scanId, scanType, body, Instant.now().toString());
-        log.info("{} sending --> {}", scanType, body);
+        List<String> scanTypes = (List<String>) properties.get(RouteConstants.SCAN_TYPE);
+
         topicDetails.put("orgId", orgId);
         topicDetails.put("runtimeAgentId", runtimeAgentId);
         topicDetails.put("messagingServiceId", messagingServiceId);
         topicDetails.put("scanId", scanId);
-        topicDetails.put("scanType", scanType);
-        topicDetails.put("isImportOp", String.valueOf(isImportOp));
+
+        ScanStatusMessage generalStatusMessage = new
+                ScanStatusMessage(orgId, scanId, status.name(), description, scanTypes);
 
         try {
-            scanDataPublisher.sendScanData(scanDataMessage, topicDetails);
+            scanStatusPublisher.sendOverallScanStatus(generalStatusMessage, topicDetails);
         } catch (Exception e) {
-            throw new ScanDataException("Scan data processor exception: " + e.getCause(),
-                    Map.of(scanId, List.of(e)), body);
+            throw new ScanStatusException("Scan status per route processor exception: " + e.getMessage(),
+                    Map.of(scanId, List.of(e)), "overall status", scanTypes, status);
         }
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessor.java
@@ -61,8 +61,8 @@ public class ScanStatusPerRouteProcessor implements Processor {
         try {
             scanStatusPublisher.sendScanDataStatus(scanDataStatusMessage, topicDetails);
         } catch (Exception e) {
-            throw new ScanStatusException("Scan status per route processor exception: " + e.getMessage(),
-                    Map.of(scanId, List.of(e)), "Per route status", List.of(scanType), status);
+            throw new ScanStatusException("Route status exception: " + e.getMessage(),
+                    Map.of(scanId, List.of(e)), "Route status", List.of(scanType), status);
         }
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/scan/ScanRecipientHierarchyEntity.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/scan/ScanRecipientHierarchyEntity.java
@@ -1,0 +1,35 @@
+package com.solace.maas.ep.event.management.agent.repository.model.scan;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.MapKeyColumn;
+import javax.persistence.Table;
+import java.util.Map;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Table(name = "SCAN_RECIPIENT_HIERARCHY")
+@Entity
+public class ScanRecipientHierarchyEntity {
+
+    @Id
+    @Column(name = "SCAN_ID")
+    private String scanId;
+
+    @ElementCollection
+    @MapKeyColumn(name = "STORE_KEY")
+    @Column(name = "PATH")
+    @CollectionTable(name = "SCAN_RECIPIENT_STORE", joinColumns = @JoinColumn(name = "SCAN_ID"))
+    private Map<String, String> store;
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/scan/ScanRecipientStoreEntity.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/scan/ScanRecipientStoreEntity.java
@@ -1,0 +1,30 @@
+package com.solace.maas.ep.event.management.agent.repository.model.scan;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Table(name = "SCAN_RECIPIENT_STORE")
+@Entity
+public class ScanRecipientStoreEntity {
+
+    @Id
+    @Column(name = "SCAN_ID")
+    private String scanId;
+
+    @Column(name = "STORE_KEY")
+    private String storeKey;
+
+    @Column(name = "PATH")
+    private String path;
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/scan/ScanRecipientHierarchyRepository.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/scan/ScanRecipientHierarchyRepository.java
@@ -1,0 +1,12 @@
+package com.solace.maas.ep.event.management.agent.repository.scan;
+
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanRecipientHierarchyEntity;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ScanRecipientHierarchyRepository extends CrudRepository<ScanRecipientHierarchyEntity, String> {
+    List<ScanRecipientHierarchyEntity> findScanRecipientHierarchyEntitiesByScanId(String scanId);
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/AbstractRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/AbstractRouteBuilder.java
@@ -1,0 +1,27 @@
+package com.solace.maas.ep.event.management.agent.route.ep;
+
+import com.solace.maas.ep.event.management.agent.route.ep.exceptionhandlers.ScanDataExceptionHandler;
+import com.solace.maas.ep.event.management.agent.route.ep.exceptionhandlers.ScanStatusExceptionHandler;
+import com.solace.maas.ep.event.management.agent.route.ep.exceptions.ScanDataException;
+import com.solace.maas.ep.event.management.agent.route.ep.exceptions.ScanStatusException;
+import org.apache.camel.builder.RouteBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public abstract class AbstractRouteBuilder extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+
+        onException(ScanStatusException.class)
+                .process(new ScanStatusExceptionHandler())
+                .to("direct:overallScanStatusPublisher?block=false&failIfNoConsumers=false")
+                .continued(true)
+                .end();
+
+        onException(ScanDataException.class)
+                .process(new ScanDataExceptionHandler())
+                .continued(true)
+                .end();
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/AbstractRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/AbstractRouteBuilder.java
@@ -21,6 +21,7 @@ public abstract class AbstractRouteBuilder extends RouteBuilder {
 
         onException(ScanDataException.class)
                 .process(new ScanDataExceptionHandler())
+                .to("direct:overallScanStatusPublisher?block=false&failIfNoConsumers=false")
                 .continued(true)
                 .end();
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanDataPublisherRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanDataPublisherRouteBuilder.java
@@ -1,14 +1,13 @@
 package com.solace.maas.ep.event.management.agent.route.ep;
 
 import com.solace.maas.ep.event.management.agent.processor.ScanDataProcessor;
-import org.apache.camel.builder.RouteBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
 @Component
 @ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
-public class ScanDataPublisherRouteBuilder extends RouteBuilder {
+public class ScanDataPublisherRouteBuilder extends AbstractRouteBuilder {
     private final ScanDataProcessor processor;
 
     @Autowired
@@ -19,13 +18,14 @@ public class ScanDataPublisherRouteBuilder extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
-        from("seda:eventPortal")
+        super.configure();
+
+        from("direct:eventPortal?block=false&failIfNoConsumers=false")
                 .routeId("scanDataPublisher")
                 .transform(body().append("\n"))
-                .process(processor)
-                .to("seda:eventPortalEndOfRoute");
+                .process(processor);
 
-        from("direct:importToEP")
+        from("direct:importToEP?block=false&failIfNoConsumers=false")
                 .routeId("importDataPublisher")
                 .transform(body().append("\n"))
                 .process(processor);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanStatusPersistenceRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanStatusPersistenceRouteBuilder.java
@@ -1,0 +1,22 @@
+package com.solace.maas.ep.event.management.agent.route.ep;
+
+import com.solace.maas.ep.event.management.agent.processor.RouteCompleteProcessorImpl;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ScanStatusPersistenceRouteBuilder extends AbstractRouteBuilder {
+    private final RouteCompleteProcessorImpl routeCompleteProcessor;
+
+    public ScanStatusPersistenceRouteBuilder(RouteCompleteProcessorImpl routeCompleteProcessor) {
+        this.routeCompleteProcessor = routeCompleteProcessor;
+    }
+
+    @Override
+    public void configure() throws Exception {
+        super.configure();
+
+        from("direct:processScanStatusAsComplete")
+                .process(routeCompleteProcessor)
+                .to("direct:perRouteScanStatusPublisher?block=false&failIfNoConsumers=false");
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanStatusPublisherRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanStatusPublisherRouteBuilder.java
@@ -1,53 +1,37 @@
 package com.solace.maas.ep.event.management.agent.route.ep;
 
-import com.solace.maas.ep.event.management.agent.processor.RouteCompleteProcessorImpl;
-import com.solace.maas.ep.event.management.agent.processor.ScanStatusProcessor;
-import com.solace.maas.ep.event.management.agent.route.ep.exceptionHandlers.ScanStatusExceptionHandler;
-import org.apache.camel.builder.RouteBuilder;
+import com.solace.maas.ep.event.management.agent.processor.ScanStatusOverAllProcessor;
+import com.solace.maas.ep.event.management.agent.processor.ScanStatusPerRouteProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
-import static org.apache.camel.support.builder.PredicateBuilder.or;
-
 @Component
 @ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
-public class ScanStatusPublisherRouteBuilder extends RouteBuilder {
-    private final ScanStatusProcessor scanStatusProcessor;
+public class ScanStatusPublisherRouteBuilder extends AbstractRouteBuilder {
+    private final ScanStatusOverAllProcessor scanStatusOverallProcessor;
 
-    private final RouteCompleteProcessorImpl routeCompleteProcessor;
+    private final ScanStatusPerRouteProcessor scanStatusPerRouteProcessor;
+
 
     @Autowired
-    public ScanStatusPublisherRouteBuilder(ScanStatusProcessor scanStatusProcessor,
-                                           RouteCompleteProcessorImpl routeCompleteProcessor) {
+    public ScanStatusPublisherRouteBuilder(ScanStatusOverAllProcessor scanStatusOverallProcessor,
+                                           ScanStatusPerRouteProcessor scanStatusPerRouteProcessor) {
         super();
-        this.scanStatusProcessor = scanStatusProcessor;
-        this.routeCompleteProcessor = routeCompleteProcessor;
+        this.scanStatusOverallProcessor = scanStatusOverallProcessor;
+        this.scanStatusPerRouteProcessor = scanStatusPerRouteProcessor;
     }
 
     @Override
-    public void configure() {
-        from("direct:processScanStatus")
-                .choice().when(or(header("DATA_PROCESSING_COMPLETE").isEqualTo(true),
-                        header("FILE_IMPORTING_COMPLETE").isEqualTo(true)))
-                .to("direct:processEndOfRoute")
-                .endChoice()
-                .end();
+    public void configure() throws Exception {
+        super.configure();
 
-        from("direct:processEndOfRoute")
-                .process(routeCompleteProcessor)
-                .onException(Exception.class)
-                .process(new ScanStatusExceptionHandler())
-                .continued(true)
-                .end()
-                .to("direct:scanStatusPublisher");
+        from("direct:perRouteScanStatusPublisher")
+                .routeId("perRouteScanStatusPublisher")
+                .process(scanStatusPerRouteProcessor);
 
-        from("direct:scanStatusPublisher")
-                .routeId("scanStatusPublisher")
-                .process(scanStatusProcessor)
-                .onException(Exception.class)
-                .process(new ScanStatusExceptionHandler())
-                .continued(true)
-                .end();
+        from("direct:overallScanStatusPublisher")
+                .routeId("overallScanStatusPublisher")
+                .process(scanStatusOverallProcessor);
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanStatusPublisherRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanStatusPublisherRouteBuilder.java
@@ -1,14 +1,18 @@
 package com.solace.maas.ep.event.management.agent.route.ep;
 
+import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.processor.ScanStatusOverAllProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanStatusPerRouteProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
 @ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@Profile("!TEST")
 public class ScanStatusPublisherRouteBuilder extends AbstractRouteBuilder {
+
     private final ScanStatusOverAllProcessor scanStatusOverallProcessor;
 
     private final ScanStatusPerRouteProcessor scanStatusPerRouteProcessor;
@@ -28,10 +32,16 @@ public class ScanStatusPublisherRouteBuilder extends AbstractRouteBuilder {
 
         from("direct:perRouteScanStatusPublisher")
                 .routeId("perRouteScanStatusPublisher")
-                .process(scanStatusPerRouteProcessor);
+                .process(scanStatusPerRouteProcessor)
+                .to("bean:scanStatusPublisher?method=sendScanDataStatus(" +
+                        "${header." + RouteConstants.SCAN_DATA_STATUS_MESSAGE + "}," +
+                        "${header." + RouteConstants.TOPIC_DETAILS + "})");
 
         from("direct:overallScanStatusPublisher")
                 .routeId("overallScanStatusPublisher")
-                .process(scanStatusOverallProcessor);
+                .process(scanStatusOverallProcessor)
+                .to("bean:scanStatusPublisher?method=sendOverallScanStatus(" +
+                        "${header." + RouteConstants.GENERAL_STATUS_MESSAGE + "}," +
+                        "${header." + RouteConstants.TOPIC_DETAILS + "})");
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/aggregation/FileParseAggregationStrategy.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/aggregation/FileParseAggregationStrategy.java
@@ -20,8 +20,6 @@ public class FileParseAggregationStrategy implements AggregationStrategy {
                 oldExchange.getIn().getHeader(RouteConstants.SCAN_TYPE));
         newExchange.getIn().setHeader(RouteConstants.SCAN_STATUS,
                 oldExchange.getIn().getHeader(RouteConstants.SCAN_STATUS));
-        newExchange.getIn().setHeader(RouteConstants.SCAN_STATUS_TYPE,
-                oldExchange.getIn().getHeader(RouteConstants.SCAN_STATUS_TYPE));
 
         return newExchange;
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptionhandlers/ScanDataExceptionHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptionhandlers/ScanDataExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.solace.maas.ep.event.management.agent.route.ep.exceptionHandlers;
+package com.solace.maas.ep.event.management.agent.route.ep.exceptionhandlers;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
@@ -7,14 +7,14 @@ import org.apache.camel.Processor;
 import static org.apache.camel.language.constant.ConstantLanguage.constant;
 
 @Slf4j
-public class ScanStatusExceptionHandler implements Processor {
+public class ScanDataExceptionHandler implements Processor {
     @Override
     public void process(Exchange exchange) throws Exception {
         Exception cause = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
 
-        log.error("An error has occurred while determining scan status: ", cause);
+        log.error("An error has occurred while streaming scan data to EP: {}", cause.toString());
 
         // Sending Error message to client
-        exchange.getIn().setHeader("SCAN_STATUS_ERROR", constant(true));
+        exchange.getIn().setHeader("SCAN_DATA_ERROR", constant(true));
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptionhandlers/ScanDataExceptionHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptionhandlers/ScanDataExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.solace.maas.ep.event.management.agent.route.ep.exceptionhandlers;
 
+import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
@@ -15,5 +17,7 @@ public class ScanDataExceptionHandler implements Processor {
         log.error("An error has occurred while streaming scan data to EP: {}", cause.toString());
 
         exchange.getIn().setHeader("SCAN_DATA_ERROR", constant(true));
+        exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.FAILED);
+        exchange.getIn().setHeader(RouteConstants.SCAN_STATUS_DESC, cause.getMessage());
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptionhandlers/ScanDataExceptionHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptionhandlers/ScanDataExceptionHandler.java
@@ -14,7 +14,6 @@ public class ScanDataExceptionHandler implements Processor {
 
         log.error("An error has occurred while streaming scan data to EP: {}", cause.toString());
 
-        // Sending Error message to client
         exchange.getIn().setHeader("SCAN_DATA_ERROR", constant(true));
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptionhandlers/ScanDataImportExceptionHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptionhandlers/ScanDataImportExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.solace.maas.ep.event.management.agent.route.ep.exceptionHandlers;
+package com.solace.maas.ep.event.management.agent.route.ep.exceptionhandlers;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptionhandlers/ScanStatusExceptionHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptionhandlers/ScanStatusExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.solace.maas.ep.event.management.agent.route.ep.exceptionhandlers;
+
+import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+
+import java.util.List;
+
+import static org.apache.camel.language.constant.ConstantLanguage.constant;
+
+@Slf4j
+public class ScanStatusExceptionHandler implements Processor {
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        Exception cause = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
+        String scanType = (String) exchange.getIn().getHeader(RouteConstants.SCAN_TYPE);
+
+        log.error("An error has occurred while determining scan status: ", cause);
+
+        // Sending Error message to client
+        exchange.getIn().setHeader("SCAN_STATUS_ERROR", constant(true));
+        exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, List.of(scanType));
+        exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.FAILED);
+        exchange.getIn().setHeader(RouteConstants.SCAN_STATUS_DESC, cause.getMessage());
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptionhandlers/ScanStatusExceptionHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptionhandlers/ScanStatusExceptionHandler.java
@@ -6,8 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 
-import java.util.List;
-
 import static org.apache.camel.language.constant.ConstantLanguage.constant;
 
 @Slf4j
@@ -15,13 +13,11 @@ public class ScanStatusExceptionHandler implements Processor {
     @Override
     public void process(Exchange exchange) throws Exception {
         Exception cause = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
-        String scanType = (String) exchange.getIn().getHeader(RouteConstants.SCAN_TYPE);
 
-        log.error("An error has occurred while determining scan status: ", cause);
+        log.error("An error has occurred while determining scan status: {}", cause.toString());
 
         // Sending Error message to client
         exchange.getIn().setHeader("SCAN_STATUS_ERROR", constant(true));
-        exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, List.of(scanType));
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.FAILED);
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS_DESC, cause.getMessage());
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptions/ClientException.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptions/ClientException.java
@@ -1,0 +1,38 @@
+package com.solace.maas.ep.event.management.agent.route.ep.exceptions;
+
+import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
+
+import java.util.List;
+import java.util.Map;
+
+@ExcludeFromJacocoGeneratedReport
+public class ClientException extends RuntimeException {
+    private String message;
+    private Map<String, List<Exception>> exceptionStore;
+
+    ClientException(final String message, final Map<String, List<Exception>> validationDetails) {
+        this.message = message;
+        this.exceptionStore = validationDetails;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public void setMessage(final String message) {
+        this.message = message;
+    }
+
+    public Map<String, List<Exception>> getExceptionStore() {
+        return this.exceptionStore;
+    }
+
+    public void setExceptionStore(final Map<String, List<Exception>> exceptionStore) {
+        this.exceptionStore = exceptionStore;
+    }
+
+    public String toString() {
+        String var10000 = this.getMessage();
+        return "ClientException(message=" + var10000 + ", validationDetails=" + this.getExceptionStore() + ")";
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptions/ScanDataException.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptions/ScanDataException.java
@@ -1,0 +1,26 @@
+package com.solace.maas.ep.event.management.agent.route.ep.exceptions;
+
+import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
+
+import java.util.List;
+import java.util.Map;
+
+@ExcludeFromJacocoGeneratedReport
+public class ScanDataException extends ClientException {
+    private final String data;
+
+    public ScanDataException(
+            String message, Map<String, List<Exception>> validationDetails,
+            String data) {
+        super(message, validationDetails);
+        this.data = data;
+    }
+
+    @Override
+    public String toString() {
+        return "ScanDataException{message=" + this.getMessage() +
+                ", exceptionStore=" + this.getExceptionStore() +
+                "data=" + data +
+                '}';
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptions/ScanStatusException.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptions/ScanStatusException.java
@@ -25,7 +25,7 @@ public class ScanStatusException extends ClientException {
     public String toString() {
         return "ScanStatusException{message=" + this.getMessage() +
                 ", exceptionStore=" + this.getExceptionStore() +
-                "statusType='" + statusType + '\'' +
+                ", statusType='" + statusType + '\'' +
                 ", scanType='" + scanTypes + '\'' +
                 ", scanStatus=" + scanStatus +
                 '}';

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptions/ScanStatusException.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/exceptions/ScanStatusException.java
@@ -1,0 +1,33 @@
+package com.solace.maas.ep.event.management.agent.route.ep.exceptions;
+
+import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
+import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
+
+import java.util.List;
+import java.util.Map;
+
+@ExcludeFromJacocoGeneratedReport
+public class ScanStatusException extends ClientException {
+    private final String statusType;
+    private final List<String> scanTypes;
+    private final ScanStatus scanStatus;
+
+    public ScanStatusException(
+            String message, Map<String, List<Exception>> validationDetails,
+            String statusType, List<String> scanTypes, ScanStatus scanStatus) {
+        super(message, validationDetails);
+        this.statusType = statusType;
+        this.scanTypes = scanTypes;
+        this.scanStatus = scanStatus;
+    }
+
+    @Override
+    public String toString() {
+        return "ScanStatusException{message=" + this.getMessage() +
+                ", exceptionStore=" + this.getExceptionStore() +
+                "statusType='" + statusType + '\'' +
+                ", scanType='" + scanTypes + '\'' +
+                ", scanStatus=" + scanStatus +
+                '}';
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ImportRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ImportRouteBuilder.java
@@ -1,6 +1,6 @@
 package com.solace.maas.ep.event.management.agent.route.manualImport;
 
-import com.solace.maas.ep.event.management.agent.route.ep.exceptionHandlers.ScanDataImportExceptionHandler;
+import com.solace.maas.ep.event.management.agent.route.ep.exceptionhandlers.ScanDataImportExceptionHandler;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataFilesZipperRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataFilesZipperRouteBuilder.java
@@ -2,7 +2,7 @@ package com.solace.maas.ep.event.management.agent.route.manualImport;
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.route.ep.aggregation.FileZipperAggregationStrategy;
-import com.solace.maas.ep.event.management.agent.route.ep.exceptionHandlers.ScanDataImportExceptionHandler;
+import com.solace.maas.ep.event.management.agent.route.ep.exceptionhandlers.ScanDataImportExceptionHandler;
 import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileBO;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseMetaInfFileRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseMetaInfFileRouteBuilder.java
@@ -3,7 +3,7 @@ package com.solace.maas.ep.event.management.agent.route.manualImport;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportOverAllStatusProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportParseMetaInfFileProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportPublishImportScanEventProcessor;
-import com.solace.maas.ep.event.management.agent.route.ep.exceptionHandlers.ScanDataImportExceptionHandler;
+import com.solace.maas.ep.event.management.agent.route.ep.exceptionhandlers.ScanDataImportExceptionHandler;
 import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileBO;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.dataformat.JsonLibrary;
@@ -49,6 +49,6 @@ public class ScanDataImportParseMetaInfFileRouteBuilder extends RouteBuilder {
         from("direct:sendOverAllInProgressImportStatus")
                 .routeId("sendOverAllInProgressImportStatus")
                 .process(scanDataImportOverAllStatusProcessor)
-                .to("direct:scanStatusPublisher");
+                .to("direct:overallScanStatusPublisher?block=false&failIfNoConsumers=false");
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/model/MetaInfFileBO.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/model/MetaInfFileBO.java
@@ -1,5 +1,6 @@
 package com.solace.maas.ep.event.management.agent.scanManager.model;
 
+import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,6 +12,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.List;
 
+@ExcludeFromJacocoGeneratedReport
 @AllArgsConstructor
 @NoArgsConstructor
 @SuperBuilder

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/model/ZipRequestBO.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/model/ZipRequestBO.java
@@ -1,12 +1,14 @@
 package com.solace.maas.ep.event.management.agent.scanManager.model;
 
 import com.solace.maas.ep.event.management.agent.model.AbstractBaseBO;
+import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+@ExcludeFromJacocoGeneratedReport
 @AllArgsConstructor
 @NoArgsConstructor
 @SuperBuilder

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/rest/RestErrorHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/rest/RestErrorHandler.java
@@ -1,0 +1,29 @@
+package com.solace.maas.ep.event.management.agent.scanManager.rest;
+
+import com.solace.maas.ep.common.model.EventErrorDTO;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+public class RestErrorHandler {
+
+    @ExceptionHandler({RestException.class})
+    @ResponseBody
+    public ResponseEntity<EventErrorDTO> handleRestException(RestException restException) {
+        EventErrorDTO eventErrorDTO = new EventErrorDTO(restException.getMessage());
+        return new ResponseEntity<>(eventErrorDTO, HttpStatus.BAD_REQUEST);
+    }
+
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    public static class RestException extends RuntimeException {
+        public RestException(String message) {
+            super(message);
+        }
+
+        public RestException(String message, Exception cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanService.java
@@ -2,14 +2,16 @@ package com.solace.maas.ep.event.management.agent.service;
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
-import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatusType;
 import com.solace.maas.ep.event.management.agent.plugin.constants.SchedulerConstants;
 import com.solace.maas.ep.event.management.agent.plugin.constants.SchedulerType;
 import com.solace.maas.ep.event.management.agent.plugin.route.RouteBundle;
+import com.solace.maas.ep.event.management.agent.plugin.route.RouteBundleHierarchyStore;
 import com.solace.maas.ep.event.management.agent.repository.model.route.RouteEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanDestinationEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanRecipientEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanRecipientHierarchyEntity;
+import com.solace.maas.ep.event.management.agent.repository.scan.ScanRecipientHierarchyRepository;
 import com.solace.maas.ep.event.management.agent.repository.scan.ScanRepository;
 import lombok.extern.slf4j.Slf4j;
 import net.logstash.logback.encoder.org.apache.commons.lang3.StringUtils;
@@ -38,15 +40,20 @@ import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteCo
 public class ScanService {
     private final ScanRepository repository;
 
+    private final ScanRecipientHierarchyRepository scanRecipientHierarchyRepository;
+
     private final ScanRouteService scanRouteService;
 
     private final RouteService routeService;
 
     private final ProducerTemplate producerTemplate;
 
-    public ScanService(ScanRepository repository, ScanRouteService scanRouteService,
+    public ScanService(ScanRepository repository,
+                       ScanRecipientHierarchyRepository scanRecipientHierarchyRepository,
+                       ScanRouteService scanRouteService,
                        RouteService routeService, ProducerTemplate producerTemplate) {
         this.repository = repository;
+        this.scanRecipientHierarchyRepository = scanRecipientHierarchyRepository;
         this.scanRouteService = scanRouteService;
         this.routeService = routeService;
         this.producerTemplate = producerTemplate;
@@ -121,11 +128,16 @@ public class ScanService {
 
         List<String> scanTypes = parseRouteBundle(routeBundles, new ArrayList<>());
 
+        RouteBundleHierarchyStore routeBundleHierarchy =
+                parseRouteRecipients(routeBundles, new RouteBundleHierarchyStore());
+
+        save(routeBundleHierarchy, scanId);
+
         log.info("Scan request [{}]: Total of {} scan types to be retrieved: [{}]",
                 scanId, scanTypes.size(), StringUtils.join(scanTypes, ", "));
 
-        send(scanId, groupId, routeBundles.stream().findFirst().orElseThrow().getMessagingServiceId(),
-                scanTypes, ScanStatus.IN_PROGRESS, ScanStatusType.OVERALL);
+        sendScanStatus(scanId, groupId, routeBundles.stream().findFirst().orElseThrow().getMessagingServiceId(),
+                scanTypes, ScanStatus.IN_PROGRESS);
 
         log.trace("RouteBundles to be processed: {}", routeBundles);
 
@@ -233,20 +245,18 @@ public class ScanService {
      * @param scanId             The Scan ID to set.
      * @param groupId            Not used at the moment. This will be the grouped Scan IDs.
      * @param messagingServiceId The ID of the Messaging Service being scanned.
-     * @param scanTypes          List of scan types.
-     * @param status             The status of scan.
-     * @param statusType         The type of scan status. Either the overall scan status, or the route status.
      * @param scanTypes          The list of scan types included in the scan request.
+     * @param status             The status of scan.
      */
-    public void send(String scanId, String groupId, String messagingServiceId, List<String> scanTypes,
-                     ScanStatus status, ScanStatusType statusType) {
-        producerTemplate.send("direct:scanStatusPublisher?block=false&failIfNoConsumers=false", exchange -> {
+    public void sendScanStatus(String scanId, String groupId, String messagingServiceId, List<String> scanTypes,
+                               ScanStatus status) {
+        producerTemplate.send("direct:overallScanStatusPublisher?block=false&failIfNoConsumers=false", exchange -> {
             exchange.getIn().setHeader(RouteConstants.SCAN_ID, scanId);
             exchange.getIn().setHeader(RouteConstants.SCHEDULE_ID, groupId);
             exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, messagingServiceId);
             exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, scanTypes);
             exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, status);
-            exchange.getIn().setHeader(RouteConstants.SCAN_STATUS_TYPE, statusType);
+            exchange.getIn().setHeader(RouteConstants.SCAN_STATUS_DESC, "");
         });
     }
 
@@ -287,6 +297,16 @@ public class ScanService {
         return repository.save(scanEntity);
     }
 
+    protected ScanRecipientHierarchyEntity save(RouteBundleHierarchyStore routeBundleHierarchy, String scanId) {
+        ScanRecipientHierarchyEntity scanRecipientHierarchyEntity =
+                ScanRecipientHierarchyEntity.builder()
+                        .store(routeBundleHierarchy.getStore())
+                        .scanId(scanId)
+                        .build();
+
+        return scanRecipientHierarchyRepository.save(scanRecipientHierarchyEntity);
+    }
+
     protected List<String> parseRouteBundle(List<RouteBundle> routeBundles, List<String> scanTypes) {
         for (RouteBundle routeBundle : routeBundles) {
             scanTypes.add(routeBundle.getScanType());
@@ -295,5 +315,50 @@ public class ScanService {
             }
         }
         return scanTypes;
+    }
+
+    protected RouteBundleHierarchyStore parseRouteRecipients(List<RouteBundle> routeBundles, RouteBundleHierarchyStore pathStore) {
+        for (RouteBundle routeBundle : routeBundles) {
+            if (routeBundle.getRecipients() != null && !routeBundle.getRecipients().isEmpty()) {
+                pathStore = registerRouteRecipients(routeBundle, pathStore);
+                parseRouteRecipients(routeBundle.getRecipients(), pathStore);
+            }
+        }
+        return pathStore;
+    }
+
+    protected RouteBundleHierarchyStore registerRouteRecipients(RouteBundle routeBundle, RouteBundleHierarchyStore pathStore) {
+        boolean parentExistsInStore = false;
+        List<String> keys = new ArrayList<>(pathStore.getStore().keySet());
+        String parentScanType = routeBundle.getScanType();
+
+        List<String> recipients = routeBundle.getRecipients().stream()
+                .map(RouteBundle::getScanType).collect(Collectors.toList());
+
+        for (String key : keys) {
+            String hierarchyPath = pathStore.getStore().get(key);
+            String lastChild = StringUtils.substringAfterLast(hierarchyPath, ",");
+
+            if (lastChild.equals(parentScanType)) {
+                String firstRecipient = recipients.get(0);
+                recipients.remove(0);
+                String firstRecipientPath = pathStore.getStore().get(key) + "," + firstRecipient;
+                pathStore.getStore().put(String.valueOf(key), firstRecipientPath);
+
+                String basePath = pathStore.getStore().get(key).split(parentScanType, 2)[0];
+                recipients.forEach(recipient -> {
+                    String path = basePath + parentScanType + "," + recipient;
+                    pathStore.getStore().put(String.valueOf(RouteBundleHierarchyStore.getStoreKey()), path);
+                });
+                parentExistsInStore = true;
+                break;
+            }
+        }
+        if (!parentExistsInStore) {
+            recipients.forEach(recipient ->
+                    pathStore.getStore().put(String.valueOf(RouteBundleHierarchyStore.getStoreKey()),
+                            parentScanType + "," + recipient));
+        }
+        return pathStore;
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanService.java
@@ -124,7 +124,8 @@ public class ScanService {
      * @param routeBundles - see description above
      * @return The id of the scan.
      */
-    public String singleScan(List<RouteBundle> routeBundles, String groupId, String scanId, MessagingServiceEntity messagingServiceEntity) {
+    public String singleScan(List<RouteBundle> routeBundles, String groupId, String scanId,
+                             MessagingServiceEntity messagingServiceEntity) {
         log.info("Scan request [{}]: Starting a single scan.", scanId);
 
         ScanEntity savedScanEntity = null;
@@ -140,7 +141,7 @@ public class ScanService {
                 scanId, scanTypes.size(), StringUtils.join(scanTypes, ", "));
 
         sendScanStatus(scanId, groupId, routeBundles.stream().findFirst().orElseThrow().getMessagingServiceId(),
-                scanTypes, ScanStatus.IN_PROGRESS);
+                StringUtils.join(scanTypes, ","), ScanStatus.IN_PROGRESS);
 
         log.trace("RouteBundles to be processed: {}", routeBundles);
 
@@ -252,10 +253,10 @@ public class ScanService {
      * @param scanId             The Scan ID to set.
      * @param groupId            Not used at the moment. This will be the grouped Scan IDs.
      * @param messagingServiceId The ID of the Messaging Service being scanned.
-     * @param scanTypes          The list of scan types included in the scan request.
+     * @param scanTypes          The scan types included in the scan request.
      * @param status             The status of scan.
      */
-    public void sendScanStatus(String scanId, String groupId, String messagingServiceId, List<String> scanTypes,
+    public void sendScanStatus(String scanId, String groupId, String messagingServiceId, String scanTypes,
                                ScanStatus status) {
         producerTemplate.send("direct:overallScanStatusPublisher?block=false&failIfNoConsumers=false", exchange -> {
             exchange.getIn().setHeader(RouteConstants.SCAN_ID, scanId);

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/TestConfig.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/TestConfig.java
@@ -10,6 +10,7 @@ import com.solace.maas.ep.event.management.agent.plugin.publisher.SolaceWebPubli
 import com.solace.maas.ep.event.management.agent.plugin.vmr.VmrProcessor;
 import com.solace.maas.ep.event.management.agent.publisher.ScanDataPublisher;
 import com.solace.maas.ep.event.management.agent.publisher.ScanLogsPublisher;
+import com.solace.maas.ep.event.management.agent.publisher.ScanStatusPublisher;
 import com.solace.maas.ep.event.management.agent.repository.messagingservice.MessagingServiceRepository;
 import com.solace.maas.ep.event.management.agent.repository.model.mesagingservice.ConnectionDetailsEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.mesagingservice.MessagingServiceEntity;
@@ -118,6 +119,12 @@ public class TestConfig {
     @Primary
     public ScanLogsPublisher scanLogsPublisher() {
         return mock(ScanLogsPublisher.class);
+    }
+
+    @Bean
+    @Primary
+    public ScanStatusPublisher scanStatusPublisher() {
+        return mock(ScanStatusPublisher.class);
     }
 
     @Bean

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/DataPublisherRouteBuilderTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/DataPublisherRouteBuilderTests.java
@@ -1,5 +1,6 @@
 package com.solace.maas.ep.event.management.agent.plugin.route.handler;
 
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.DataPublisherRouteBuilder;
 import lombok.AllArgsConstructor;
@@ -90,12 +91,13 @@ public class DataPublisherRouteBuilderTests {
         @Primary
         public static RoutesBuilder createRouteBuilder() {
             MDCProcessor mdcProcessor = mock(MDCProcessor.class);
+            EmptyScanEntityProcessor emptyScanEntityProcessor = mock(EmptyScanEntityProcessor.class);
 
             return new DataPublisherRouteBuilder(exchange -> {
                 List<TestEvent> testData = generateTestData();
 
                 exchange.getIn().setBody(testData);
-            }, "dataPublisherRoute", "topicListing", null, mdcProcessor);
+            }, "dataPublisherRoute", "topicListing", null, mdcProcessor, emptyScanEntityProcessor);
         }
     }
 }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanDataImportParseMetaInfFileRouteBuilderTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanDataImportParseMetaInfFileRouteBuilderTests.java
@@ -64,7 +64,8 @@ public class ScanDataImportParseMetaInfFileRouteBuilderTests {
                         exchange1.getIn().setHeader("CamelFileName", "META_INF.json");
                         exchange1.getIn().setBody(getMetaInfJson());
                     });
-                    route.weaveByToUri("direct:sendOverAllInProgressImportStatus").replace().to("mock:sendOverAllInProgressImportStatus");
+                    route.weaveByToUri("direct:sendOverAllInProgressImportStatus")
+                            .replace().to("mock:sendOverAllInProgressImportStatus");
                     route.weaveAddLast().to("mock:direct:mockParseMetaInfoResult");
                 });
 
@@ -82,7 +83,8 @@ public class ScanDataImportParseMetaInfFileRouteBuilderTests {
 
         AdviceWith.adviceWith(camelContext, "sendOverAllInProgressImportStatus",
                 route -> {
-                    route.weaveByToUri("direct:scanStatusPublisher").replace().to("mock:scanStatusPublisher");
+                    route.weaveByToUri("direct:overallScanStatusPublisher")
+                            .replace().to("mock:overallScanStatusPublisher");
                     route.weaveAddLast().to("mock:direct:mockSendOverAllInProgressImportStatusResult");
                 });
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanDataImportRouteBuilderTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanDataImportRouteBuilderTests.java
@@ -48,7 +48,7 @@ public class ScanDataImportRouteBuilderTests {
     private MockEndpoint mockResult;
 
     private static byte[] getZippedText(String entryName) throws IOException {
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream("TEXT".getBytes(StandardCharsets.UTF_8));
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream("TEXT" .getBytes(StandardCharsets.UTF_8));
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         ZipOutputStream zipOutputStream = new ZipOutputStream(byteArrayOutputStream);
         try {
@@ -75,6 +75,8 @@ public class ScanDataImportRouteBuilderTests {
         AdviceWith.adviceWith(camelContext, "importScanData",
                 route -> {
                     route.replaceFromWith("direct:importScanData");
+                    route.weaveByToUri("direct:checkZipSizeAndUnzipFiles")
+                            .replace().to("mock:checkZipSizeAndUnzipFiles");
                     route.weaveAddLast().to("mock:direct:result");
                 });
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanDataImportStreamFilesRouteBuilderTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanDataImportStreamFilesRouteBuilderTests.java
@@ -69,7 +69,8 @@ public class ScanDataImportStreamFilesRouteBuilderTests {
 
         AdviceWith.adviceWith(camelContext, "parseAndStreamImportFiles",
                 route -> {
-                    route.weaveByToUri("direct:scanStatusPublisher").replace().to("mock:scanStatusPublisher");
+                    route.weaveByToUri("direct:perRouteScanStatusPublisher")
+                            .replace().to("mock:perRouteScanStatusPublisher");
                     route.weaveByType(PollEnrichDefinition.class).replace().process(exchange1 ->
                             exchange1.getIn().setHeader("CamelFileName", "topicListing.json"));
                     route.weaveByToUri("direct:streamImportFiles").replace().to("mock:streamImportFiles");
@@ -116,7 +117,7 @@ public class ScanDataImportStreamFilesRouteBuilderTests {
 
         AdviceWith.adviceWith(camelContext, "processEndOfFileImportStatus",
                 route -> {
-                    route.weaveByToUri("direct:processScanStatus").replace().to("mock:processScanStatus");
+                    route.weaveByToUri("direct:processScanStatusAsComplete").replace().to("mock:processScanStatusAsComplete");
                     route.weaveAddLast().to("mock:direct:processEndOfFileImportStatusResult");
                 });
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanStatusPublisherRouteBuilderTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanStatusPublisherRouteBuilderTests.java
@@ -107,6 +107,7 @@ public class ScanStatusPublisherRouteBuilderTests {
 
         exchange.getIn().setHeader(RouteConstants.SCAN_ID, "scan1");
         exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, "messagingService");
+        exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, "queueListing");
 
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.IN_PROGRESS);
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/EmptyScanEntityProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/EmptyScanEntityProcessorTests.java
@@ -1,0 +1,96 @@
+package com.solace.maas.ep.event.management.agent.processor;
+
+import com.solace.maas.ep.event.management.agent.TestConfig;
+import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanRecipientHierarchyEntity;
+import com.solace.maas.ep.event.management.agent.repository.scan.ScanRecipientHierarchyRepository;
+import lombok.SneakyThrows;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.Rule;
+import org.junit.jupiter.api.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("TEST")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
+public class EmptyScanEntityProcessorTests {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Autowired
+    CamelContext camelContext;
+
+    @Spy
+    @InjectMocks
+    EmptyScanEntityProcessorImpl emptyScanEntityProcessor;
+
+    @Mock
+    private ScanRecipientHierarchyRepository scanRecipientHierarchyRepository;
+
+    @Mock
+    private ProducerTemplate producerTemplate;
+
+    @SneakyThrows
+    @Test
+    public void testEmptyScanEntityProcessor() {
+        Exchange exchange = new DefaultExchange(camelContext);
+
+        exchange.getIn().setHeader(RouteConstants.SCAN_ID, "scanId");
+        exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, "topicListing");
+        exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, "messagingServiceId");
+
+        exchange.getIn().setBody(new ArrayList<>());
+
+        Map<String, String> store = new LinkedHashMap<>();
+        store.put("0", "clusterConfiguration,brokerConfiguration");
+        store.put("1", "topicListing,topicConfiguration");
+        store.put("2", "topicListing,overrideTopicConfiguration");
+        store.put("3", "consumerGroups,consumerGroupConfiguration");
+
+        ScanRecipientHierarchyEntity scanRecipientHierarchyEntity =
+                ScanRecipientHierarchyEntity.builder()
+                        .scanId("scanId")
+                        .store(store)
+                        .build();
+
+        List<ScanRecipientHierarchyEntity> result = List.of(scanRecipientHierarchyEntity);
+
+        when(scanRecipientHierarchyRepository.findScanRecipientHierarchyEntitiesByScanId("scanId"))
+                .thenReturn(result);
+
+        emptyScanEntityProcessor.process(exchange);
+
+        assertThatNoException();
+
+        verify(emptyScanEntityProcessor, times(1))
+                .sendCompleteStatusForScanType("scanId", "messagingServiceId", "topicListing");
+        verify(emptyScanEntityProcessor, times(1))
+                .sendCompleteStatusForScanType("scanId", "messagingServiceId", "topicConfiguration");
+        verify(emptyScanEntityProcessor, times(1))
+                .sendCompleteStatusForScanType("scanId", "messagingServiceId", "overrideTopicConfiguration");
+
+
+        exchange.setProperty(Exchange.EXCEPTION_CAUGHT, new Exception());
+        emptyScanEntityProcessor.process(exchange);
+
+        exception.expect(Exception.class);
+    }
+}

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessorTests.java
@@ -7,6 +7,7 @@ import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants
 import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
 import com.solace.maas.ep.event.management.agent.publisher.ScanStatusPublisher;
 import lombok.SneakyThrows;
+import net.logstash.logback.encoder.org.apache.commons.lang3.StringUtils;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.support.DefaultExchange;
@@ -50,7 +51,7 @@ public class ScanStatusOverAllProcessorTests {
         Exchange exchange = new DefaultExchange(camelContext);
         exchange.getIn().setHeader(RouteConstants.SCAN_ID, "scan1");
         exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, "messagingServiceId");
-        exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, scanTypes);
+        exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, StringUtils.join(scanTypes, ","));
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.IN_PROGRESS);
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS_DESC, "description");
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessorTests.java
@@ -1,10 +1,10 @@
 package com.solace.maas.ep.event.management.agent.processor;
 
+import com.solace.maas.ep.common.messages.ScanStatusMessage;
 import com.solace.maas.ep.event.management.agent.TestConfig;
 import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
-import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatusType;
 import com.solace.maas.ep.event.management.agent.publisher.ScanStatusPublisher;
 import lombok.SneakyThrows;
 import org.apache.camel.CamelContext;
@@ -17,15 +17,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.HashMap;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 
 @ActiveProfiles("TEST")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
 @SuppressWarnings("PMD")
-public class ScanStatusProcessorTests {
+public class ScanStatusOverAllProcessorTests {
 
     @Mock
     ScanStatusPublisher scanStatusPublisher;
@@ -37,38 +40,31 @@ public class ScanStatusProcessorTests {
     private CamelContext camelContext;
 
     @InjectMocks
-    private ScanStatusProcessor scanStatusProcessor;
+    private ScanStatusOverAllProcessor scanStatusOverAllProcessor;
 
     @SneakyThrows
     @Test
     public void testScanStatusProcessor() {
+        List<String> scanTypes = List.of("topicListing", "topicConfiguration", "overrideTopicConfiguration");
 
         Exchange exchange = new DefaultExchange(camelContext);
         exchange.getIn().setHeader(RouteConstants.SCAN_ID, "scan1");
-        exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, "messagingService");
+        exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, "messagingServiceId");
+        exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, scanTypes);
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.IN_PROGRESS);
-        exchange.getIn().setHeader(RouteConstants.SCAN_STATUS_TYPE, ScanStatusType.OVERALL);
 
-        exchange.getIn().setBody(List.of("queueListing"));
+        ScanStatusMessage scanStatusMessage = new
+                ScanStatusMessage(null, "scan1", ScanStatus.IN_PROGRESS.name(), "", scanTypes);
 
-        scanStatusProcessor.process(exchange);
+        HashMap<String, String> topicDetails = new HashMap<>();
+        topicDetails.put("orgId", null);
+        topicDetails.put("runtimeAgentId", null);
+        topicDetails.put("messagingServiceId", "messagingServiceId");
+        topicDetails.put("scanId", "scan1");
 
-        assertThatNoException();
-    }
-
-    @SneakyThrows
-    @Test
-    public void testScanDataStatusProcessor() {
-
-        Exchange exchange = new DefaultExchange(camelContext);
-        exchange.getIn().setHeader(RouteConstants.SCAN_ID, "scan1");
-        exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, "messagingService");
-        exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, "queueListing");
-        exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.COMPLETE);
-        exchange.getIn().setHeader(RouteConstants.SCAN_STATUS_TYPE, ScanStatusType.PER_ROUTE);
-
-        scanStatusProcessor.process(exchange);
+        scanStatusOverAllProcessor.process(exchange);
 
         assertThatNoException();
+        verify(scanStatusPublisher, times(1)).sendOverallScanStatus(scanStatusMessage, topicDetails);
     }
 }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusOverAllProcessorTests.java
@@ -5,7 +5,6 @@ import com.solace.maas.ep.event.management.agent.TestConfig;
 import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
-import com.solace.maas.ep.event.management.agent.publisher.ScanStatusPublisher;
 import lombok.SneakyThrows;
 import net.logstash.logback.encoder.org.apache.commons.lang3.StringUtils;
 import org.apache.camel.CamelContext;
@@ -22,17 +21,12 @@ import java.util.HashMap;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 
 @ActiveProfiles("TEST")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
 @SuppressWarnings("PMD")
 public class ScanStatusOverAllProcessorTests {
-
-    @Mock
-    ScanStatusPublisher scanStatusPublisher;
 
     @Mock
     EventPortalProperties eventPortalProperties;
@@ -67,6 +61,5 @@ public class ScanStatusOverAllProcessorTests {
         scanStatusOverAllProcessor.process(exchange);
 
         assertThatNoException();
-        verify(scanStatusPublisher, times(1)).sendOverallScanStatus(scanStatusMessage, topicDetails);
     }
 }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessorTests.java
@@ -5,7 +5,6 @@ import com.solace.maas.ep.event.management.agent.TestConfig;
 import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
-import com.solace.maas.ep.event.management.agent.publisher.ScanStatusPublisher;
 import lombok.SneakyThrows;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
@@ -20,17 +19,12 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 
 @ActiveProfiles("TEST")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
 @SuppressWarnings("PMD")
 public class ScanStatusPerRouteProcessorTests {
-
-    @Mock
-    ScanStatusPublisher scanStatusPublisher;
 
     @Mock
     EventPortalProperties eventPortalProperties;
@@ -67,6 +61,5 @@ public class ScanStatusPerRouteProcessorTests {
         scanStatusPerRouteProcessor.process(exchange);
 
         assertThatNoException();
-        verify(scanStatusPublisher, times(1)).sendScanDataStatus(scanDataStatusMessage, topicDetails);
     }
 }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanStatusPerRouteProcessorTests.java
@@ -1,0 +1,71 @@
+package com.solace.maas.ep.event.management.agent.processor;
+
+import com.solace.maas.ep.common.messages.ScanDataStatusMessage;
+import com.solace.maas.ep.event.management.agent.TestConfig;
+import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
+import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
+import com.solace.maas.ep.event.management.agent.publisher.ScanStatusPublisher;
+import lombok.SneakyThrows;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+@ActiveProfiles("TEST")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
+@SuppressWarnings("PMD")
+public class ScanStatusPerRouteProcessorTests {
+
+    @Mock
+    ScanStatusPublisher scanStatusPublisher;
+
+    @Mock
+    EventPortalProperties eventPortalProperties;
+
+    @Autowired
+    private CamelContext camelContext;
+
+    @InjectMocks
+    private ScanStatusPerRouteProcessor scanStatusPerRouteProcessor;
+
+    @SneakyThrows
+    @Test
+    public void testScanStatusProcessor() {
+
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.getIn().setHeader(RouteConstants.SCAN_ID, "scan1");
+        exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, "messagingServiceId");
+
+        exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, "queueListing");
+        exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.IN_PROGRESS);
+
+        ScanDataStatusMessage scanDataStatusMessage = new
+                ScanDataStatusMessage(null, "scan1", ScanStatus.IN_PROGRESS.name(), "", "queueListing");
+
+        HashMap<String, String> topicDetails = new HashMap<>();
+        topicDetails.put("orgId", null);
+        topicDetails.put("runtimeAgentId", null);
+        topicDetails.put("messagingServiceId", "messagingServiceId");
+        topicDetails.put("scanId", "scan1");
+        topicDetails.put("status", ScanStatus.IN_PROGRESS.name());
+        topicDetails.put("scanDataType", "queueListing");
+
+        scanStatusPerRouteProcessor.process(exchange);
+
+        assertThatNoException();
+        verify(scanStatusPublisher, times(1)).sendScanDataStatus(scanDataStatusMessage, topicDetails);
+    }
+}

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManagerTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/ScanManagerTest.java
@@ -1,20 +1,32 @@
 package com.solace.maas.ep.event.management.agent.scanManager;
 
 import com.solace.maas.ep.event.management.agent.TestConfig;
+import com.solace.maas.ep.event.management.agent.plugin.kafka.route.delegate.KafkaRouteDelegateImpl;
+import com.solace.maas.ep.event.management.agent.plugin.localstorage.route.delegate.DataCollectionFileWriterDelegateImpl;
+import com.solace.maas.ep.event.management.agent.plugin.manager.loader.PluginLoader;
+import com.solace.maas.ep.event.management.agent.plugin.route.RouteBundle;
 import com.solace.maas.ep.event.management.agent.repository.model.mesagingservice.MessagingServiceEntity;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ScanRequestBO;
 import com.solace.maas.ep.event.management.agent.service.MessagingServiceDelegateServiceImpl;
 import com.solace.maas.ep.event.management.agent.service.ScanService;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ActiveProfiles("TEST")
@@ -31,7 +43,8 @@ public class ScanManagerTest {
     private ScanService scanService;
 
     @Test
-    public void testScanManager() {
+    @SneakyThrows
+    public void testScanManagerExceptions() {
         MessagingServiceEntity messagingServiceEntity = MessagingServiceEntity.builder()
                 .id("id")
                 .name("name")
@@ -56,5 +69,133 @@ public class ScanManagerTest {
         ScanRequestBO scanRequestBOConsumerGroups =
                 new ScanRequestBO("id", "scanId", List.of("TEST_SCAN_2"), List.of());
         Assertions.assertThrows(NullPointerException.class, () -> scanManager.scan(scanRequestBO));
+    }
+
+    @Test
+    @SneakyThrows
+    public void testScanManager() {
+        String messagingServiceId = "messagingServiceId";
+        ScanRequestBO scanRequestBO =
+                new ScanRequestBO(messagingServiceId, "scanId", List.of("KAFKA_ALL"), List.of("FILE_WRITER"));
+
+        MessagingServiceEntity messagingServiceEntity = MessagingServiceEntity.builder()
+                .id(messagingServiceId)
+                .name("name")
+                .messagingServiceType("kafka")
+                .managementDetails(List.of())
+                .build();
+
+        KafkaRouteDelegateImpl scanDelegate =
+                mock(KafkaRouteDelegateImpl.class);
+
+        DataCollectionFileWriterDelegateImpl dataCollectionFileWriterDelegate =
+                mock(DataCollectionFileWriterDelegateImpl.class);
+
+        when(messagingServiceDelegateService.getMessagingServiceById(messagingServiceId))
+                .thenReturn(messagingServiceEntity);
+
+        List<RouteBundle> destinations = getFileWriterDestination(messagingServiceId);
+        List<RouteBundle> routes = getKafkaRoutes(destinations, messagingServiceId);
+
+        try (MockedStatic<PluginLoader> pluginLoaderMockedStatic = Mockito.mockStatic(PluginLoader.class)) {
+            pluginLoaderMockedStatic.when(() -> PluginLoader.findPlugin("kafka"))
+                    .thenReturn(scanDelegate);
+            pluginLoaderMockedStatic.when(() -> PluginLoader.findPlugin("FILE_WRITER"))
+                    .thenReturn(dataCollectionFileWriterDelegate);
+            when(dataCollectionFileWriterDelegate.generateRouteList(
+                    List.of(),
+                    List.of(),
+                    scanRequestBO.getScanTypes().stream().findFirst().orElseThrow(),
+                    messagingServiceId))
+                    .thenReturn(destinations);
+            when(scanDelegate.generateRouteList(destinations, List.of(), "KAFKA_ALL", messagingServiceId))
+                    .thenReturn(routes);
+            when(scanService.singleScan(List.of(), "groupId", "scanId"))
+                    .thenReturn(Mockito.anyString());
+
+            scanManager.scan(scanRequestBO);
+
+            assertThatNoException();
+            verify(scanService, times(1))
+                    .singleScan(eq(routes), any(String.class), eq(scanRequestBO.getScanId()));
+        }
+    }
+
+    private List<RouteBundle> getFileWriterDestination(String messagingServiceId) {
+        return List.of(RouteBundle.builder()
+                .destinations(List.of())
+                .recipients(List.of())
+                .messagingServiceId(messagingServiceId)
+                .routeId("seda:dataCollectionFileWrite")
+                .scanType("KAFKA_ALL")
+                .firstRouteInChain(false)
+                .build());
+    }
+
+    private List<RouteBundle> getKafkaRoutes(List<RouteBundle> destinations, String messagingServiceId) {
+        RouteBundle brokerConfiguration = RouteBundle.builder()
+                .destinations(destinations)
+                .recipients(List.of())
+                .messagingServiceId(messagingServiceId)
+                .routeId("kafkaBrokerConfiguration")
+                .scanType("brokerConfiguration")
+                .firstRouteInChain(false)
+                .build();
+
+        RouteBundle topicConfiguration = RouteBundle.builder()
+                .destinations(destinations)
+                .recipients(List.of())
+                .messagingServiceId(messagingServiceId)
+                .routeId("kafkaTopicConfiguration")
+                .scanType("topicConfiguration")
+                .firstRouteInChain(false)
+                .build();
+
+        RouteBundle overrideTopicConfiguration = RouteBundle.builder()
+                .destinations(destinations)
+                .recipients(List.of())
+                .messagingServiceId(messagingServiceId)
+                .routeId("kafkaOverrideTopicConfiguration")
+                .scanType("overrideTopicConfiguration")
+                .firstRouteInChain(false)
+                .build();
+
+        RouteBundle consumerGroupConfiguration = RouteBundle.builder()
+                .destinations(destinations)
+                .recipients(List.of())
+                .messagingServiceId(messagingServiceId)
+                .routeId("kafkaConsumerGroupConfiguration")
+                .scanType("consumerGroupConfiguration")
+                .firstRouteInChain(false)
+                .build();
+
+        return List.of(
+                RouteBundle.builder()
+                        .destinations(destinations)
+                        .recipients(List.of(brokerConfiguration))
+                        .messagingServiceId(messagingServiceId)
+                        .routeId("kafkaClusterConfiguration")
+                        .scanType("clusterConfiguration")
+                        .firstRouteInChain(true)
+                        .build(),
+
+                RouteBundle.builder()
+                        .destinations(destinations)
+                        .recipients(List.of(topicConfiguration, overrideTopicConfiguration))
+                        .messagingServiceId(messagingServiceId)
+                        .routeId("kafkaDataPublisher")
+                        .scanType("topicListing")
+                        .firstRouteInChain(true)
+                        .build(),
+
+                RouteBundle.builder()
+                        .destinations(destinations)
+                        .recipients(List.of(consumerGroupConfiguration))
+                        .messagingServiceId(messagingServiceId)
+                        .routeId("kafkaConsumerGroupDataPublisher")
+                        .scanType("consumerGroups")
+                        .firstRouteInChain(true)
+                        .build()
+        );
     }
 }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/EMAControllerTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/EMAControllerTest.java
@@ -2,11 +2,16 @@ package com.solace.maas.ep.event.management.agent.scanManager.rest;
 
 import com.solace.maas.ep.common.model.ScanRequestDTO;
 import com.solace.maas.ep.event.management.agent.TestConfig;
+import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
+import com.solace.maas.ep.event.management.agent.config.eventPortal.GatewayMessagingProperties;
+import com.solace.maas.ep.event.management.agent.config.eventPortal.GatewayProperties;
 import com.solace.maas.ep.event.management.agent.scanManager.ScanManager;
 import com.solace.maas.ep.event.management.agent.scanManager.mapper.ScanRequestMapper;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ScanRequestBO;
 import com.solace.maas.ep.event.management.agent.util.IDGenerator;
+import org.junit.Rule;
 import org.junit.jupiter.api.Test;
+import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
@@ -23,24 +28,31 @@ import static org.mockito.Mockito.when;
 @ActiveProfiles("TEST")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
 public class EMAControllerTest {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     @Autowired
     private ScanRequestMapper scanRequestMapper;
 
 
     @Test
-    public void EMAControllerTest() {
+    public void testEMAController() {
         ScanManager scanManager = mock(ScanManager.class);
         IDGenerator idGenerator = mock(IDGenerator.class);
+        EventPortalProperties eventPortalProperties = mock(EventPortalProperties.class);
 
         ScanRequestDTO scanRequestDTO = new ScanRequestDTO(List.of("topics"), List.of());
         ScanRequestBO scanRequestBO = new ScanRequestBO("id", "scanId",
                 List.of("TEST_SCAN"), List.of());
 
+        when(eventPortalProperties.getGateway())
+                .thenReturn(GatewayProperties.builder()
+                        .messaging(GatewayMessagingProperties.builder().standalone(false).build())
+                        .build());
         when(scanManager.scan(scanRequestBO))
                 .thenReturn("scanId");
 
-        EMAController controller = new EMAControllerImpl(scanRequestMapper, scanManager, idGenerator);
+        EMAController controller = new EMAControllerImpl(scanRequestMapper, scanManager, idGenerator, eventPortalProperties);
 
         ResponseEntity<String> reply =
                 controller.scan("id", scanRequestDTO);
@@ -49,5 +61,33 @@ public class EMAControllerTest {
         assertThat(reply.getBody()).contains("Scan started.");
 
         assertThatNoException();
+    }
+
+    @Test
+    public void testEMAControllerInStandAlone() {
+        ScanManager scanManager = mock(ScanManager.class);
+        IDGenerator idGenerator = mock(IDGenerator.class);
+        EventPortalProperties eventPortalProperties = mock(EventPortalProperties.class);
+
+        ScanRequestDTO scanRequestDTO = new ScanRequestDTO(List.of("topics"), List.of("EVENT_PORTAL"));
+        ScanRequestBO scanRequestBO = new ScanRequestBO("id", "scanId",
+                List.of("TEST_SCAN"), List.of("EVENT_PORTAL"));
+
+        when(eventPortalProperties.getGateway())
+                .thenReturn(GatewayProperties.builder()
+                        .messaging(GatewayMessagingProperties.builder().standalone(true).build())
+                        .build());
+        when(scanManager.scan(scanRequestBO))
+                .thenReturn("scanId");
+
+        EMAController controller = new EMAControllerImpl(scanRequestMapper, scanManager, idGenerator, eventPortalProperties);
+
+        ResponseEntity<String> reply =
+                controller.scan("id", scanRequestDTO);
+
+        assertThat(reply.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(reply.getBody()).contains("Scan data could not be streamed to EP in standalone mode.");
+
+        exception.expect(Exception.class);
     }
 }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ScanServiceTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ScanServiceTests.java
@@ -256,7 +256,8 @@ public class ScanServiceTests {
     public void testSendScanStatus() {
         ScanService service = new ScanService(mock(ScanRepository.class), mock(ScanRecipientHierarchyRepository.class),
                 mock(ScanRouteService.class), mock(RouteService.class), template);
-        service.sendScanStatus("scanId", "groupId", "messagingServiceId", List.of(), ScanStatus.IN_PROGRESS);
+        service.sendScanStatus("scanId", "groupId", "messagingServiceId",
+                "queueListing", ScanStatus.IN_PROGRESS);
 
         assertThatNoException();
     }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ScanServiceTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ScanServiceTests.java
@@ -2,20 +2,28 @@ package com.solace.maas.ep.event.management.agent.service;
 
 import com.solace.maas.ep.event.management.agent.TestConfig;
 import com.solace.maas.ep.event.management.agent.logging.StreamingAppender;
+import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
 import com.solace.maas.ep.event.management.agent.plugin.route.RouteBundle;
+import com.solace.maas.ep.event.management.agent.plugin.route.RouteBundleHierarchyStore;
 import com.solace.maas.ep.event.management.agent.processor.RouteCompleteProcessorImpl;
 import com.solace.maas.ep.event.management.agent.repository.model.route.RouteEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanRecipientHierarchyEntity;
+import com.solace.maas.ep.event.management.agent.repository.scan.ScanRecipientHierarchyRepository;
 import com.solace.maas.ep.event.management.agent.repository.scan.ScanRepository;
 import com.solace.maas.ep.event.management.agent.service.logging.LoggingService;
+import lombok.SneakyThrows;
 import org.apache.camel.Processor;
+import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -23,6 +31,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ActiveProfiles("TEST")
@@ -41,6 +50,9 @@ public class ScanServiceTests {
     private ScanRepository scanRepository;
 
     @Mock
+    private ScanRecipientHierarchyRepository scanRecipientHierarchyRepository;
+
+    @Mock
     private RouteService routeService;
 
     @Mock
@@ -52,17 +64,29 @@ public class ScanServiceTests {
     @Mock
     private RouteCompleteProcessorImpl routeCompleteProcessor;
 
+    @Produce
+    private ProducerTemplate template;
+
     @InjectMocks
     private ScanService scanService;
 
     @Test
-    public void testSingleScanWithRouteBundle() throws Exception {
-        RouteBundle routeBundleChained = RouteBundle.builder()
+    @SneakyThrows
+    public void testSingleScanWithRouteBundle() {
+        RouteBundle consumerGroupsConfiguration = RouteBundle.builder()
                 .messagingServiceId("service1")
                 .routeId("route1")
-                .scanType("topicListing")
+                .scanType("consumerGroupsConfiguration")
                 .destinations(List.of())
                 .recipients(List.of())
+                .build();
+
+        RouteBundle consumerGroups = RouteBundle.builder()
+                .messagingServiceId("service1")
+                .routeId("route1")
+                .scanType("consumerGroups")
+                .destinations(List.of())
+                .recipients(List.of(consumerGroupsConfiguration))
                 .build();
 
         RouteBundle routeBundleDestination = RouteBundle.builder()
@@ -73,12 +97,52 @@ public class ScanServiceTests {
                 .recipients(List.of())
                 .build();
 
-        RouteBundle routeBundle = RouteBundle.builder()
+        RouteBundle topicConfiguration = RouteBundle.builder()
+                .messagingServiceId("service1")
+                .routeId("route1")
+                .scanType("topicConfiguration")
+                .destinations(List.of())
+                .recipients(List.of())
+                .build();
+
+        RouteBundle overrideTopicConfiguration = RouteBundle.builder()
+                .messagingServiceId("service1")
+                .routeId("route1")
+                .scanType("overrideTopicConfiguration")
+                .destinations(List.of())
+                .recipients(List.of())
+                .build();
+
+        RouteBundle topicListing = RouteBundle.builder()
                 .messagingServiceId("service1")
                 .routeId("route1")
                 .scanType("topicListing")
                 .destinations(List.of(routeBundleDestination))
-                .recipients(List.of(routeBundleChained))
+                .recipients(List.of(topicConfiguration, overrideTopicConfiguration))
+                .build();
+
+        RouteBundle additionalConsumerGroupConfigPart1 = RouteBundle.builder()
+                .messagingServiceId("service1")
+                .routeId("route1")
+                .scanType("additionalConsumerGroupConfigPart1")
+                .destinations(List.of(routeBundleDestination))
+                .recipients(List.of())
+                .build();
+
+        RouteBundle additionalConsumerGroupConfigPart2 = RouteBundle.builder()
+                .messagingServiceId("service1")
+                .routeId("route1")
+                .scanType("additionalConsumerGroupConfigPart2")
+                .destinations(List.of(routeBundleDestination))
+                .recipients(List.of())
+                .build();
+
+        RouteBundle additionalConsumerGroupConfigBundle = RouteBundle.builder()
+                .messagingServiceId("service1")
+                .routeId("route1")
+                .scanType("consumerGroupsConfiguration")
+                .destinations(List.of(routeBundleDestination))
+                .recipients(List.of(additionalConsumerGroupConfigPart1, additionalConsumerGroupConfigPart2))
                 .build();
 
         RouteEntity returnedEntity = RouteEntity.builder()
@@ -105,13 +169,98 @@ public class ScanServiceTests {
                 .thenReturn(CompletableFuture.completedFuture(null));
         when(scanRepository.save(scanEntity))
                 .thenReturn(scanEntity);
+        when(scanRecipientHierarchyRepository.save(any(ScanRecipientHierarchyEntity.class)))
+                .thenReturn(mock(ScanRecipientHierarchyEntity.class));
 
-        scanService.singleScan(List.of(routeBundle), "groupId", "scanId");
+        scanService.singleScan(List.of(topicListing, consumerGroups, additionalConsumerGroupConfigBundle), "groupId", "scanId");
 
         assertThatNoException();
     }
 
     @Test
+    @SneakyThrows
+    public void testParseRouteRecipients() {
+        RouteBundle brokerConfiguration = RouteBundle.builder()
+                .messagingServiceId("service1")
+                .routeId("kafkaBrokerConfiguration")
+                .scanType("brokerConfiguration")
+                .destinations(List.of())
+                .recipients(List.of())
+                .build();
+
+        RouteBundle clusterConfiguration = RouteBundle.builder()
+                .messagingServiceId("service1")
+                .routeId("kafkaClusterConfiguration")
+                .scanType("clusterConfiguration")
+                .destinations(List.of())
+                .recipients(List.of(brokerConfiguration))
+                .build();
+
+        RouteBundle topicConfiguration = RouteBundle.builder()
+                .messagingServiceId("service1")
+                .routeId("kafkaTopicConfiguration")
+                .scanType("topicConfiguration")
+                .destinations(List.of())
+                .recipients(List.of())
+                .build();
+
+        RouteBundle overrideTopicConfiguration = RouteBundle.builder()
+                .messagingServiceId("service1")
+                .routeId("kafkaOverrideTopicConfiguration")
+                .scanType("overrideTopicConfiguration")
+                .destinations(List.of())
+                .recipients(List.of())
+                .build();
+
+        RouteBundle topicListing = RouteBundle.builder()
+                .messagingServiceId("service1")
+                .routeId("kafkaDataPublisher")
+                .scanType("topicListing")
+                .destinations(List.of())
+                .recipients(List.of(topicConfiguration, overrideTopicConfiguration))
+                .build();
+
+        RouteBundle consumerGroupConfiguration = RouteBundle.builder()
+                .messagingServiceId("service1")
+                .routeId("kafkaConsumerGroupConfiguration")
+                .scanType("consumerGroupConfiguration")
+                .destinations(List.of())
+                .recipients(List.of())
+                .build();
+
+        RouteBundle consumerGroups = RouteBundle.builder()
+                .messagingServiceId("service1")
+                .routeId("kafkaConsumerGroupDataPublisher")
+                .scanType("consumerGroups")
+                .destinations(List.of())
+                .recipients(List.of(consumerGroupConfiguration))
+                .build();
+
+        RouteBundleHierarchyStore routeBundleHierarchyStore =
+                scanService.parseRouteRecipients(List.of(clusterConfiguration, topicListing, consumerGroups),
+                        new RouteBundleHierarchyStore());
+
+        List<String> routeBundlerHierarchySore = new ArrayList<>(routeBundleHierarchyStore.getStore().values());
+
+        Assertions.assertEquals(4, routeBundlerHierarchySore.size());
+        Assertions.assertTrue(routeBundlerHierarchySore.contains("clusterConfiguration,brokerConfiguration"));
+        Assertions.assertTrue(routeBundlerHierarchySore.contains("topicListing,topicConfiguration"));
+        Assertions.assertTrue(routeBundlerHierarchySore.contains("topicListing,overrideTopicConfiguration"));
+        Assertions.assertTrue(routeBundlerHierarchySore.contains("consumerGroups,consumerGroupConfiguration"));
+    }
+
+    @Test
+    @SneakyThrows
+    public void testSendScanStatus() {
+        ScanService service = new ScanService(mock(ScanRepository.class), mock(ScanRecipientHierarchyRepository.class),
+                mock(ScanRouteService.class), mock(RouteService.class), template);
+        service.sendScanStatus("scanId", "groupId", "messagingServiceId", List.of(), ScanStatus.IN_PROGRESS);
+
+        assertThatNoException();
+    }
+
+    @Test
+    @SneakyThrows
     public void testFindById() {
         when(scanRepository.findById(any(String.class)))
                 .thenReturn(Optional.of(ScanEntity.builder().build()));

--- a/service/application/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker.txt
+++ b/service/application/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker.txt
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaBrokerConfigurationDataPublisherRouteBuilder.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaBrokerConfigurationDataPublisherRouteBuilder.java
@@ -3,6 +3,7 @@ package com.solace.maas.ep.event.management.agent.plugin.kafka.route.handler;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.cluster.KafkaBrokerConfigurationProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteId;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteType;
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.route.aggregation.GenericListScanIdAggregationStrategy;
 import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.DataAggregationRouteBuilder;
@@ -14,8 +15,9 @@ import org.springframework.stereotype.Component;
 public class KafkaBrokerConfigurationDataPublisherRouteBuilder extends DataAggregationRouteBuilder {
     @Autowired
     public KafkaBrokerConfigurationDataPublisherRouteBuilder(KafkaBrokerConfigurationProcessor processor,
-                                                             RouteManager routeManager, MDCProcessor mdcProcessor) {
+                                                             RouteManager routeManager, MDCProcessor mdcProcessor,
+                                                             EmptyScanEntityProcessor emptyScanEntityProcessor) {
         super(processor, KafkaRouteId.KAFKA_BROKER_CONFIGURATION.label, KafkaRouteType.KAFKA_BROKER_CONFIGURATION.label,
-                routeManager, new GenericListScanIdAggregationStrategy(), 1000, mdcProcessor);
+                routeManager, new GenericListScanIdAggregationStrategy(), 1000, mdcProcessor, emptyScanEntityProcessor);
     }
 }

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaClusterConfigurationDataPublisherRouteBuilder.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaClusterConfigurationDataPublisherRouteBuilder.java
@@ -3,6 +3,7 @@ package com.solace.maas.ep.event.management.agent.plugin.kafka.route.handler;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.cluster.KafkaClusterConfigurationProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteId;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteType;
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.DataPublisherRouteBuilder;
 import com.solace.maas.ep.event.management.agent.plugin.route.manager.RouteManager;
@@ -13,8 +14,9 @@ import org.springframework.stereotype.Component;
 public class KafkaClusterConfigurationDataPublisherRouteBuilder extends DataPublisherRouteBuilder {
     @Autowired
     public KafkaClusterConfigurationDataPublisherRouteBuilder(KafkaClusterConfigurationProcessor processor,
-                                                              RouteManager routeManager, MDCProcessor mdcProcessor) {
+                                                              RouteManager routeManager, MDCProcessor mdcProcessor,
+                                                              EmptyScanEntityProcessor emptyScanEntityProcessor) {
         super(processor, KafkaRouteId.KAFKA_CLUSTER_CONFIGURATION.label, KafkaRouteType.KAFKA_CUSTER_CONFIGURATION.label,
-                routeManager, mdcProcessor);
+                routeManager, mdcProcessor, emptyScanEntityProcessor);
     }
 }

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaConsumerGroupConfigurationDataPublisherRouteBuilder.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaConsumerGroupConfigurationDataPublisherRouteBuilder.java
@@ -3,6 +3,7 @@ package com.solace.maas.ep.event.management.agent.plugin.kafka.route.handler;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.consumer.KafkaConsumerGroupConfigurationProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteId;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteType;
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.route.aggregation.GenericListScanIdAggregationStrategy;
 import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.DataAggregationRouteBuilder;
@@ -19,9 +20,10 @@ public class KafkaConsumerGroupConfigurationDataPublisherRouteBuilder extends Da
 
     @Autowired
     public KafkaConsumerGroupConfigurationDataPublisherRouteBuilder(KafkaConsumerGroupConfigurationProcessor processor,
-                                                                    RouteManager routeManager, MDCProcessor mdcProcessor) {
+                                                                    RouteManager routeManager, MDCProcessor mdcProcessor,
+                                                                    EmptyScanEntityProcessor emptyScanEntityProcessor) {
         super(processor, KafkaRouteId.KAFKA_CONSUMER_GROUP_CONFIGURATION.label,
                 KafkaRouteType.KAFKA_CONSUMER_GROUP_CONFIGURATION.label, routeManager,
-                new GenericListScanIdAggregationStrategy(), 1000, mdcProcessor);
+                new GenericListScanIdAggregationStrategy(), 1000, mdcProcessor, emptyScanEntityProcessor);
     }
 }

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaConsumerGroupDataPublisherRouteBuilder.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaConsumerGroupDataPublisherRouteBuilder.java
@@ -3,6 +3,7 @@ package com.solace.maas.ep.event.management.agent.plugin.kafka.route.handler;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.consumer.KafkaConsumerGroupProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteId;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteType;
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.DataPublisherRouteBuilder;
 import com.solace.maas.ep.event.management.agent.plugin.route.manager.RouteManager;
@@ -17,8 +18,8 @@ public class KafkaConsumerGroupDataPublisherRouteBuilder extends DataPublisherRo
      */
     @Autowired
     public KafkaConsumerGroupDataPublisherRouteBuilder(KafkaConsumerGroupProcessor processor, RouteManager routeManager,
-                                                       MDCProcessor mdcProcessor) {
+                                                       MDCProcessor mdcProcessor, EmptyScanEntityProcessor emptyScanEntityProcessor) {
         super(processor, KafkaRouteId.KAFKA_CONSUMER_GROUPS.label, KafkaRouteType.KAFKA_CONSUMER_GROUPS.label,
-                routeManager, mdcProcessor);
+                routeManager, mdcProcessor, emptyScanEntityProcessor);
     }
 }

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaDataPublisherRouteBuilder.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaDataPublisherRouteBuilder.java
@@ -3,6 +3,7 @@ package com.solace.maas.ep.event.management.agent.plugin.kafka.route.handler;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.topic.KafkaTopicListingProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteId;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteType;
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.DataPublisherRouteBuilder;
 import com.solace.maas.ep.event.management.agent.plugin.route.manager.RouteManager;
@@ -16,8 +17,8 @@ public class KafkaDataPublisherRouteBuilder extends DataPublisherRouteBuilder {
      */
     @Autowired
     public KafkaDataPublisherRouteBuilder(KafkaTopicListingProcessor processor, RouteManager routeManager,
-                                          MDCProcessor mdcProcessor) {
+                                          MDCProcessor mdcProcessor, EmptyScanEntityProcessor emptyScanEntityProcessor) {
         super(processor, KafkaRouteId.KAFKA_TOPIC_LISTING.label, KafkaRouteType.KAFKA_TOPIC_LISTING.label,
-                routeManager, mdcProcessor);
+                routeManager, mdcProcessor, emptyScanEntityProcessor);
     }
 }

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaFeatureDataPublisherRouteBuilder.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaFeatureDataPublisherRouteBuilder.java
@@ -3,6 +3,7 @@ package com.solace.maas.ep.event.management.agent.plugin.kafka.route.handler;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.feature.KafkaFeaturesProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteId;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteType;
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.DataPublisherRouteBuilder;
 import com.solace.maas.ep.event.management.agent.plugin.route.manager.RouteManager;
@@ -13,8 +14,8 @@ import org.springframework.stereotype.Component;
 public class KafkaFeatureDataPublisherRouteBuilder extends DataPublisherRouteBuilder {
     @Autowired
     public KafkaFeatureDataPublisherRouteBuilder(KafkaFeaturesProcessor processor, RouteManager routeManager,
-                                                 MDCProcessor mdcProcessor) {
+                                                 MDCProcessor mdcProcessor, EmptyScanEntityProcessor emptyScanEntityProcessor) {
         super(processor, KafkaRouteId.KAFKA_FEATURES.label, KafkaRouteType.KAFKA_FEATURES.label,
-                routeManager, mdcProcessor);
+                routeManager, mdcProcessor, emptyScanEntityProcessor);
     }
 }

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaOverrideTopicConfigurationDataPublisherRouteBuilder.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaOverrideTopicConfigurationDataPublisherRouteBuilder.java
@@ -3,6 +3,7 @@ package com.solace.maas.ep.event.management.agent.plugin.kafka.route.handler;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.topic.KafkaOverrideTopicConfigurationProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteId;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteType;
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.route.aggregation.GenericListScanIdAggregationStrategy;
 import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.DataAggregationRouteBuilder;
@@ -12,9 +13,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class KafkaOverrideTopicConfigurationDataPublisherRouteBuilder extends DataAggregationRouteBuilder {
     public KafkaOverrideTopicConfigurationDataPublisherRouteBuilder(KafkaOverrideTopicConfigurationProcessor processor,
-                                                                    RouteManager routeManager, MDCProcessor mdcProcessor) {
+                                                                    RouteManager routeManager, MDCProcessor mdcProcessor,
+                                                                    EmptyScanEntityProcessor emptyScanEntityProcessor) {
         super(processor, KafkaRouteId.KAFKA_OVERRIDE_TOPIC_CONFIGURATION.label,
                 KafkaRouteType.KAFKA_OVERRIDE_TOPIC_CONFIGURATION.label, routeManager,
-                new GenericListScanIdAggregationStrategy(), 1000, mdcProcessor);
+                new GenericListScanIdAggregationStrategy(), 1000, mdcProcessor, emptyScanEntityProcessor);
     }
 }

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaTopicConfigurationDataPublisherRouteBuilder.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaTopicConfigurationDataPublisherRouteBuilder.java
@@ -3,6 +3,7 @@ package com.solace.maas.ep.event.management.agent.plugin.kafka.route.handler;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.topic.KafkaTopicConfigurationProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteId;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteType;
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.route.aggregation.GenericListScanIdAggregationStrategy;
 import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.DataAggregationRouteBuilder;
@@ -16,8 +17,9 @@ public class KafkaTopicConfigurationDataPublisherRouteBuilder extends DataAggreg
      * @param routeManager The list of Route Destinations the Data Collection events will be streamed to.
      */
     public KafkaTopicConfigurationDataPublisherRouteBuilder(KafkaTopicConfigurationProcessor processor,
-                                                            RouteManager routeManager, MDCProcessor mdcProcessor) {
+                                                            RouteManager routeManager, MDCProcessor mdcProcessor,
+                                                            EmptyScanEntityProcessor emptyScanEntityProcessor) {
         super(processor, KafkaRouteId.KAFKA_TOPIC_CONFIGURATION.label, KafkaRouteType.KAFKA_TOPIC_CONFIGURATION.label,
-                routeManager, new GenericListScanIdAggregationStrategy(), 1000, mdcProcessor);
+                routeManager, new GenericListScanIdAggregationStrategy(), 1000, mdcProcessor, emptyScanEntityProcessor);
     }
 }

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaTopicProducerDataPublisherRouteBuilder.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/handler/KafkaTopicProducerDataPublisherRouteBuilder.java
@@ -3,6 +3,7 @@ package com.solace.maas.ep.event.management.agent.plugin.kafka.route.handler;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.topic.KafkaTopicProducerProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteId;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.route.enumeration.KafkaRouteType;
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.route.aggregation.GenericListScanIdAggregationStrategy;
 import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.DataAggregationRouteBuilder;
@@ -12,8 +13,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class KafkaTopicProducerDataPublisherRouteBuilder extends DataAggregationRouteBuilder {
     public KafkaTopicProducerDataPublisherRouteBuilder(KafkaTopicProducerProcessor processor, RouteManager routeManager,
-                                                       MDCProcessor mdcProcessor) {
+                                                       MDCProcessor mdcProcessor, EmptyScanEntityProcessor emptyScanEntityProcessor) {
         super(processor, KafkaRouteId.KAFKA_PRODUCERS.label, KafkaRouteType.KAFKA_PRODUCERS.label, routeManager,
-                new GenericListScanIdAggregationStrategy(), 1000, mdcProcessor);
+                new GenericListScanIdAggregationStrategy(), 1000, mdcProcessor, emptyScanEntityProcessor);
     }
 }

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
@@ -20,4 +20,10 @@ public class RouteConstants {
     public static final String MESSAGING_SERVICE_ID = "MESSAGING_SERVICE_ID";
 
     public static final String IS_DATA_IMPORT = "IS_DATA_IMPORT";
+
+    public static final String GENERAL_STATUS_MESSAGE = "GENERAL_STATUS_MESSAGE";
+
+    public static final String SCAN_DATA_STATUS_MESSAGE = "SCAN_DATA_STATUS_MESSAGE";
+
+    public static final String TOPIC_DETAILS = "TOPIC_DETAILS";
 }

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
@@ -13,7 +13,7 @@ public class RouteConstants {
 
     public static final String SCAN_STATUS = "SCAN_STATUS";
 
-    public static final String SCAN_STATUS_TYPE = "SCAN_STATUS_TYPE";
+    public static final String SCAN_STATUS_DESC = "SCAN_STATUS_DESCRIPTION";
 
     public static final String AGGREGATION_ID = "AGGREGATION_ID";
 

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/ScanStatusType.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/ScanStatusType.java
@@ -1,6 +1,0 @@
-package com.solace.maas.ep.event.management.agent.plugin.constants;
-
-public enum ScanStatusType {
-    OVERALL,
-    PER_ROUTE
-}

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/processor/EmptyScanEntityProcessor.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/processor/EmptyScanEntityProcessor.java
@@ -1,0 +1,6 @@
+package com.solace.maas.ep.event.management.agent.plugin.processor;
+
+import org.apache.camel.Processor;
+
+public abstract class EmptyScanEntityProcessor implements Processor {
+}

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/RouteBundleHierarchyStore.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/RouteBundleHierarchyStore.java
@@ -1,0 +1,21 @@
+package com.solace.maas.ep.event.management.agent.plugin.route;
+
+import lombok.Data;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+
+@Data
+public class RouteBundleHierarchyStore {
+    private static int storeKey = 0;
+    private Map<String, String> store;
+
+    public RouteBundleHierarchyStore() {
+        store = new LinkedHashMap<>();
+    }
+
+    public static int getStoreKey() {
+        return storeKey++;
+    }
+}

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/AsyncDataPublisherRouteBuilder.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/AsyncDataPublisherRouteBuilder.java
@@ -3,6 +3,7 @@ package com.solace.maas.ep.event.management.agent.plugin.route.handler.base;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.constants.SchedulerConstants;
 import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.route.manager.RouteManager;
 import org.apache.camel.Exchange;
@@ -31,8 +32,9 @@ public class AsyncDataPublisherRouteBuilder extends DataPublisherRouteBuilder {
      * @param mdcProcessor The Processor handling the MDC data for logging.
      */
     public AsyncDataPublisherRouteBuilder(Processor processor, AsyncRoutePublisherImpl asyncRoutePublisher, String routeId,
-                                          String routeType, RouteManager routeManager, MDCProcessor mdcProcessor) {
-        super(processor, routeId, routeType, routeManager, mdcProcessor);
+                                          String routeType, RouteManager routeManager, MDCProcessor mdcProcessor,
+                                          EmptyScanEntityProcessor emptyScanEntityProcessor) {
+        super(processor, routeId, routeType, routeManager, mdcProcessor, emptyScanEntityProcessor);
 
         this.asyncRoutePublisher = asyncRoutePublisher;
     }

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/DataPublisherRouteBuilder.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/DataPublisherRouteBuilder.java
@@ -89,8 +89,13 @@ public class DataPublisherRouteBuilder extends RouteBuilder {
                 .shareUnitOfWork()
                 .choice().when(simple("${body.size} == 0"))
                 .process(emptyScanEntityProcessor)
-                .endChoice()
+                .split(simple("${header." + RouteConstants.SCAN_TYPE + "}"))
+                .to("direct:processScanStatusAsComplete?block=false&failIfNoConsumers=false")
+                .log("Scan request [${header." + RouteConstants.SCAN_ID + "}]: The status of [${header."
+                        + RouteConstants.SCAN_TYPE + "}]" + " is: [" + ScanStatus.COMPLETE + "].")
                 .end()
+                .endChoice()
+                .otherwise()
                 .split(body()).streaming().shareUnitOfWork()
                 // Transforming the Events to JSON. Do we need to do this here? Maybe we should delegate this to the
                 // destinations instead?
@@ -106,6 +111,8 @@ public class DataPublisherRouteBuilder extends RouteBuilder {
                 .to("direct:processScanStatusAsComplete?block=false&failIfNoConsumers=false")
                 .log("Scan request [${header." + RouteConstants.SCAN_ID + "}]: The status of [${header."
                         + RouteConstants.SCAN_TYPE + "}]" + " is: [" + ScanStatus.COMPLETE + "].")
+                .endChoice()
+                .end()
                 .endChoice()
                 .end();
 

--- a/service/rabbitmq-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/rabbitmq/route/handler/RabbitMqQueueDataPublisherRoute.java
+++ b/service/rabbitmq-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/rabbitmq/route/handler/RabbitMqQueueDataPublisherRoute.java
@@ -1,5 +1,6 @@
 package com.solace.maas.ep.event.management.agent.plugin.rabbitmq.route.handler;
 
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.rabbitmq.processor.queue.RabbitMqQueueProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.rabbitmq.route.enumeration.RabbitMqRouteId;
@@ -11,8 +12,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class RabbitMqQueueDataPublisherRoute extends DataPublisherRouteBuilder {
     public RabbitMqQueueDataPublisherRoute(RabbitMqQueueProcessor processor, RouteManager routeManager,
-                                           MDCProcessor mdcProcessor) {
+                                           MDCProcessor mdcProcessor, EmptyScanEntityProcessor emptyScanEntityProcessor) {
         super(processor, RabbitMqRouteId.RABBIT_MQ_QUEUE.label, RabbitMqRouteType.RABBIT_MQ_QUEUE.label,
-                routeManager, mdcProcessor);
+                routeManager, mdcProcessor, emptyScanEntityProcessor);
     }
 }

--- a/service/solace-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/solace/route/handler/SolaceDataPublisherRouteBuilder.java
+++ b/service/solace-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/solace/route/handler/SolaceDataPublisherRouteBuilder.java
@@ -1,5 +1,6 @@
 package com.solace.maas.ep.event.management.agent.plugin.solace.route.handler;
 
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.DataPublisherRouteBuilder;
 import com.solace.maas.ep.event.management.agent.plugin.route.manager.RouteManager;
@@ -16,8 +17,8 @@ public class SolaceDataPublisherRouteBuilder extends DataPublisherRouteBuilder {
      */
     @Autowired
     public SolaceDataPublisherRouteBuilder(SolaceQueueListingProcessor processor, RouteManager routeManager,
-                                           MDCProcessor mdcProcessor) {
+                                           MDCProcessor mdcProcessor, EmptyScanEntityProcessor emptyScanEntityProcessor) {
         super(processor, SolaceRouteId.SOLACE_QUEUE_LISTING.label, SolaceRouteType.SOLACE_QUEUE_LISTING.label,
-                routeManager, mdcProcessor);
+                routeManager, mdcProcessor, emptyScanEntityProcessor);
     }
 }

--- a/service/solace-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/solace/route/handler/SolaceQueueConfigurationRouteBuilder.java
+++ b/service/solace-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/solace/route/handler/SolaceQueueConfigurationRouteBuilder.java
@@ -1,5 +1,6 @@
 package com.solace.maas.ep.event.management.agent.plugin.solace.route.handler;
 
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.DataPublisherRouteBuilder;
 import com.solace.maas.ep.event.management.agent.plugin.route.manager.RouteManager;
@@ -16,8 +17,8 @@ public class SolaceQueueConfigurationRouteBuilder extends DataPublisherRouteBuil
      */
     @Autowired
     public SolaceQueueConfigurationRouteBuilder(SolaceQueueConfigurationProcessor processor, RouteManager routeManager,
-                                                MDCProcessor mdcProcessor) {
+                                                MDCProcessor mdcProcessor, EmptyScanEntityProcessor emptyScanEntityProcessor) {
         super(processor, SolaceRouteId.SOLACE_QUEUE_CONFIG.label, SolaceRouteType.SOLACE_QUEUE_CONFIG.label,
-                routeManager, mdcProcessor);
+                routeManager, mdcProcessor, emptyScanEntityProcessor);
     }
 }

--- a/service/solace-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/solace/route/handler/SolaceSubscriptionConfigurationDataPublisherRouteBuilder.java
+++ b/service/solace-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/solace/route/handler/SolaceSubscriptionConfigurationDataPublisherRouteBuilder.java
@@ -1,5 +1,6 @@
 package com.solace.maas.ep.event.management.agent.plugin.solace.route.handler;
 
+import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.route.aggregation.GenericListScanIdAggregationStrategy;
 import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.DataAggregationRouteBuilder;
@@ -16,8 +17,9 @@ public class SolaceSubscriptionConfigurationDataPublisherRouteBuilder extends Da
      * @param routeManager The list of Route Destinations the Data Collection events will be streamed to.
      */
     public SolaceSubscriptionConfigurationDataPublisherRouteBuilder(SolaceSubscriptionProcessor processor,
-                                                                    RouteManager routeManager, MDCProcessor mdcProcessor) {
+                                                                    RouteManager routeManager, MDCProcessor mdcProcessor,
+                                                                    EmptyScanEntityProcessor emptyScanEntityProcessor) {
         super(processor, SolaceRouteId.SOLACE_SUBSCRIPTION_CONFIG.label, SolaceRouteType.SOLACE_SUBSCRIPTION_CONFIG.label,
-                routeManager, new GenericListScanIdAggregationStrategy(), 10, mdcProcessor);
+                routeManager, new GenericListScanIdAggregationStrategy(), 10, mdcProcessor, emptyScanEntityProcessor);
     }
 }


### PR DESCRIPTION
### What is the purpose of this change?

Enhance the scan status and error reporting from EMA

### How was this change implemented?

1. Refactoring the scan status route to make it simpler and separate the overall status from the per-route status.
2. Fix the out of order scan status and scan data messages by changing the event portal endpoint to become a direct component
3. Fix the complete scan status for EMA in offline mode (complete status is persisted in DB)
4. Fix the complete scan status for EMA in offline mode (complete status is logged into the console)
5. Implement the complete status for empty scan types and its descendent in the RouteBundle hierarchy after parsing the hierarchy (no depth constraint) and extract all possible root-to-leaf paths
6. Introduce a new exception handling route at global level.
7. Introduce custom exception classes for Scan status and scan data publisher.
8. Introduce exception handlers for scan status and scan data publisher
9. Improve the unit tests for Scan manager and scan service

### How was this change tested?

Manual + unit tests

### Is there anything the reviewers should focus on/be aware of?
N/A
