### PR TITLE
Update DataAggregationRouteBuilder to send complete status message for empty scan types

### DIFF
--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/DataAggregationRouteBuilder.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/DataAggregationRouteBuilder.java
@@ -62,11 +62,7 @@ public class DataAggregationRouteBuilder extends DataPublisherRouteBuilder {
                 .setHeader("DESTINATIONS", method(this, "getDestinations(${header."
                         + RouteConstants.SCAN_ID + "})"))
                 .setHeader(RouteConstants.SCAN_STATUS, constant(ScanStatus.IN_PROGRESS))
-                .log("Scan request [${header." + RouteConstants.SCAN_ID + "}]: The status of [${header."
-                        + RouteConstants.SCAN_TYPE + "}]" + " is: [" + ScanStatus.IN_PROGRESS + "].")
-                .to("direct:perRouteScanStatusPublisher?block=false&failIfNoConsumers=false")
-                .log("Scan request [${header." + RouteConstants.SCAN_ID + "}]: Retrieving [${header." + RouteConstants.SCAN_TYPE
-                        + "}] details from messaging service [${header." + RouteConstants.MESSAGING_SERVICE_ID + "}].")
+                .to("direct:markRouteScanStatusInProgress?block=false&failIfNoConsumers=false")
 
                 // Data Collected by the Processor is expected to be an Array. We'll be splitting this Array
                 // and streaming it back to interested parties. Interceptors / Destination routes will need to
@@ -86,12 +82,11 @@ public class DataAggregationRouteBuilder extends DataPublisherRouteBuilder {
                 // connects to the Messaging Service.
                 .log(LoggingLevel.TRACE, "agg complete ${body}")
                 .process(processor)
+                // Checking for empty scan types.
                 .choice().when(simple("${body.size} == 0"))
                 .process(emptyScanEntityProcessor)
                 .split(simple("${header." + RouteConstants.SCAN_TYPE + "}"))
-                .to("direct:processScanStatusAsComplete?block=false&failIfNoConsumers=false")
-                .log("Scan request [${header." + RouteConstants.SCAN_ID + "}]: The status of the empty scan type [${header."
-                        + RouteConstants.SCAN_TYPE + "}]" + " is: [" + ScanStatus.COMPLETE + "].")
+                .to("direct:markRouteScanStatusComplete?block=false&failIfNoConsumers=false")
                 .end()
                 .endChoice()
                 .otherwise()
@@ -122,9 +117,7 @@ public class DataAggregationRouteBuilder extends DataPublisherRouteBuilder {
                 .recipientList().header("DESTINATIONS").delimiter(";")
                 .shareUnitOfWork()
                 .choice().when(header("DATA_PROCESSING_COMPLETE").isEqualTo(true))
-                .to("direct:processScanStatusAsComplete?block=false&failIfNoConsumers=false")
-                .log("Scan request [${header." + RouteConstants.SCAN_ID + "}]: The status of [${header."
-                        + RouteConstants.SCAN_TYPE + "}]" + " is: [" + ScanStatus.COMPLETE + "].")
+                .to("direct:markRouteScanStatusComplete?block=false&failIfNoConsumers=false")
                 .endChoice()
                 .end()
                 .endChoice()

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/DataPublisherRouteBuilder.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/DataPublisherRouteBuilder.java
@@ -91,7 +91,7 @@ public class DataPublisherRouteBuilder extends RouteBuilder {
                 .process(emptyScanEntityProcessor)
                 .split(simple("${header." + RouteConstants.SCAN_TYPE + "}"))
                 .to("direct:processScanStatusAsComplete?block=false&failIfNoConsumers=false")
-                .log("Scan request [${header." + RouteConstants.SCAN_ID + "}]: The status of [${header."
+                .log("Scan request [${header." + RouteConstants.SCAN_ID + "}]: The status of the empty scan type [${header."
                         + RouteConstants.SCAN_TYPE + "}]" + " is: [" + ScanStatus.COMPLETE + "].")
                 .end()
                 .endChoice()

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/ScanStatusMarkerAndLoggerRouteBuilder.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/base/ScanStatusMarkerAndLoggerRouteBuilder.java
@@ -1,0 +1,28 @@
+package com.solace.maas.ep.event.management.agent.plugin.route.handler.base;
+
+import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
+import org.apache.camel.builder.RouteBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ScanStatusMarkerAndLoggerRouteBuilder extends RouteBuilder {
+
+
+    @Override
+    public void configure() throws Exception {
+
+        from("direct:markRouteScanStatusInProgress")
+                .log("Scan request [${header." + RouteConstants.SCAN_ID + "}]: The status of [${header."
+                        + RouteConstants.SCAN_TYPE + "}]" + " is: [" + ScanStatus.IN_PROGRESS + "].")
+                .to("direct:perRouteScanStatusPublisher?block=false&failIfNoConsumers=false")
+                .log("Scan request [${header." + RouteConstants.SCAN_ID + "}]: Retrieving [${header." + RouteConstants.SCAN_TYPE
+                        + "}] details from messaging service [${header." + RouteConstants.MESSAGING_SERVICE_ID + "}].");
+
+
+        from("direct:markRouteScanStatusComplete")
+                .to("direct:processScanStatusAsComplete?block=false&failIfNoConsumers=false")
+                .log("Scan request [${header." + RouteConstants.SCAN_ID + "}]: The status of [${header."
+                        + RouteConstants.SCAN_TYPE + "}]" + " is: [" + ScanStatus.COMPLETE + "].");
+    }
+}


### PR DESCRIPTION
### What is the purpose of this change?

To send complete status message for aggregated empty scan types.

### How was this change implemented?

By updating the `DataAggregationRouteBuilder` to check and send complete status message for aggregated empty scan types.

### How was this change tested?

Manual

### Is there anything the reviewers should focus on/be aware of?

N/A
