### PR TITLE
DATAGO-50106: revert camel library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ data_collection
 
 application-mysql-*.yml
 .env
+
+*dependency-reduced-pom.xml

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -15,7 +15,6 @@
     <description>event-management-agent application</description>
 
     <properties>
-        <camel.version>3.19.0</camel.version>
         <springdoc.version>1.6.11</springdoc.version>
         <snakeyaml.version>1.31</snakeyaml.version>
     </properties>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <org.json.version>20210307</org.json.version>
-        <camel.version>3.19.0</camel.version>
+        <camel.version>3.16.0</camel.version>
         <snakeyaml.version>1.31</snakeyaml.version>
         <jacksondatabind.version>2.13.4.2</jacksondatabind.version>
     </properties>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -20,7 +20,6 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <snakeyaml.version>1.31</snakeyaml.version>
-        <camel.version>3.19.0</camel.version>
     </properties>
 
     <dependencies>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -41,6 +41,7 @@
         <logstash.version>6.6</logstash.version>
         <org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
         <jacoco.line.percentage>0.8</jacoco.line.percentage>
+        <camel.version>3.16.0</camel.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### What is the purpose of this change?
The new camel library had backward incompatible changes and was causing errors uploading the zip file for import

### How was this change implemented?
Reverted the camel library back to 3.16.0

### How was this change tested?
Manually tested. The io exception disappeared

### Is there anything the reviewers should focus on/be aware of?
No
