### PR TITLE
DATAGO-49514: Throttle the data and log events

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanDataPublisherRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanDataPublisherRouteBuilder.java
@@ -23,11 +23,13 @@ public class ScanDataPublisherRouteBuilder extends AbstractRouteBuilder {
         from("direct:eventPortal?block=false&failIfNoConsumers=false")
                 .routeId("scanDataPublisher")
                 .transform(body().append("\n"))
+                .throttle(100)
                 .process(processor);
 
         from("direct:importToEP?block=false&failIfNoConsumers=false")
                 .routeId("importDataPublisher")
                 .transform(body().append("\n"))
+                .throttle(100)
                 .process(processor);
 
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanLogsPublisherRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/ScanLogsPublisherRouteBuilder.java
@@ -14,13 +14,14 @@ public class ScanLogsPublisherRouteBuilder extends RouteBuilder {
     @Autowired
     public ScanLogsPublisherRouteBuilder(ScanLogsProcessor processor) {
         super();
-        this.scanLogsProcessor = processor;
+        scanLogsProcessor = processor;
     }
 
     @Override
     public void configure() throws Exception {
         from("seda:scanLogsPublisher?blockWhenFull=true&size=1000000")
                 .routeId("scanLogsPublisher")
+                .throttle(100)
                 .process(scanLogsProcessor);
     }
 }


### PR DESCRIPTION
### What is the purpose of this change?

Throttle the EMA until we get either handshaking or persistent send with instant ack.

### How was this change implemented?

Added throttling to data and log route builders

### How was this change tested?

Manual testing with scaled data sets.

### Is there anything the reviewers should focus on/be aware of?

This is just a quick fix, ultimately we would like to use some sort of handshaking or persistent sends in order to get proper feedback from either EP or the messaging service.
