### PR TITLE
Prevent scan requests via REST endpoint in connected mode

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/rest/EMAControllerImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/rest/EMAControllerImpl.java
@@ -53,7 +53,11 @@ public class EMAControllerImpl implements EMAController {
             boolean isEMAStandalone = eventPortalProperties.getGateway().getMessaging().isStandalone();
             List<String> destinations = scanRequestBO.getDestinations();
 
-            if (isEMAStandalone && destinations.contains("EVENT_PORTAL")) {
+            if (!isEMAStandalone) {
+                throw new RestErrorHandler.RestException("Scan requests via REST endpoint could not be initiated in connected mode.");
+            }
+
+            if (destinations.contains("EVENT_PORTAL")) {
                 throw new RestErrorHandler.RestException("Scan data could not be streamed to EP in standalone mode.");
             }
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/EMAControllerTest.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/EMAControllerTest.java
@@ -21,7 +21,6 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -40,7 +39,7 @@ public class EMAControllerTest {
 
 
     @Test
-    public void testEMAController() {
+    public void testEMAControllerInConnectedMode() {
         ScanManager scanManager = mock(ScanManager.class);
         IDGenerator idGenerator = mock(IDGenerator.class);
         EventPortalProperties eventPortalProperties = mock(EventPortalProperties.class);
@@ -53,18 +52,20 @@ public class EMAControllerTest {
                 .thenReturn(GatewayProperties.builder()
                         .messaging(GatewayMessagingProperties.builder().standalone(false).build())
                         .build());
+
         when(scanManager.scan(scanRequestBO))
                 .thenReturn("scanId");
 
-        EMAController controller = new EMAControllerImpl(scanRequestMapper, scanManager, idGenerator, eventPortalProperties);
+        EMAController controller =
+                new EMAControllerImpl(scanRequestMapper, scanManager, idGenerator, eventPortalProperties);
 
-        ResponseEntity<String> reply =
-                controller.scan("id", scanRequestDTO);
+        ResponseEntity<String> reply = controller.scan("id", scanRequestDTO);
 
-        assertThat(reply.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(reply.getBody()).contains("Scan started.");
+        // Scan requests via REST endpoints are prevented in connected mode, e.g., standalone=false
+        assertThat(reply.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(reply.getBody()).contains("Scan requests via REST endpoint could not be initiated in connected mode.");
 
-        assertThatNoException();
+        exception.expect(Exception.class);
     }
 
     @Test


### PR DESCRIPTION
### What is the purpose of this change?

To prevent the scan requests via REST endpoint when EMA is in connected mode, e.g., `standalone=false`.

### How was this change implemented?

By updating the `EMAController`

### How was this change tested?

Manual + unit tests.

### Is there anything the reviewers should focus on/be aware of?

N/A