### PR TITLE
simplify DataImportController Zip endpoint

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/model/ZipRequestBO.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/model/ZipRequestBO.java
@@ -16,15 +16,5 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class ZipRequestBO extends AbstractBaseBO<String> {
 
-    private String messagingServiceId;
-
     private String scanId;
-
-    @Override
-    public String toString() {
-        return "ZipRequestBO{" +
-                "messagingServiceId='" + messagingServiceId + '\'' +
-                ", scanId='" + scanId + '\'' +
-                '}';
-    }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportController.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportController.java
@@ -38,7 +38,6 @@ public interface DataImportController {
             summary = "Zips data collection files",
             description = "Use this API to zip the data collection files for the specified messaging service.",
             parameters = {
-                    @Parameter(name = "messagingServiceId", description = "The ID of the messaging service.", required = true),
                     @Parameter(name = "scanId", description = "The ID of the scan request.", required = true),
             },
             responses = {
@@ -53,5 +52,5 @@ public interface DataImportController {
                     )
             }
     )
-    ResponseEntity<InputStreamResource> zip(String messagingServiceId, String scanId);
+    ResponseEntity<InputStreamResource> zip(String scanId);
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportControllerImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportControllerImpl.java
@@ -58,12 +58,10 @@ public class DataImportControllerImpl implements DataImportController {
     }
 
     @Override
-    @GetMapping(value = "/{messagingServiceId}/export/{scanId}/zip")
-    public ResponseEntity<InputStreamResource> zip(@PathVariable(value = "messagingServiceId") String messagingServiceId,
-                                                   @PathVariable(value = "scanId") String scanId) {
+    @GetMapping(value = "/export/{scanId}/zip")
+    public ResponseEntity<InputStreamResource> zip(@PathVariable(value = "scanId") String scanId) {
         try {
             ZipRequestBO zipRequestBO = ZipRequestBO.builder()
-                    .messagingServiceId(messagingServiceId)
                     .scanId(scanId)
                     .build();
 
@@ -71,6 +69,7 @@ public class DataImportControllerImpl implements DataImportController {
 
             InputStream zipInputStream = importService.zip(zipRequestBO);
             InputStreamResource inputStreamResource = new InputStreamResource(zipInputStream);
+
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE);
             httpHeaders.set(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=" + scanId + ".zip");

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ImportService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ImportService.java
@@ -88,7 +88,7 @@ public class ImportService {
 
         String scheduleId = StringUtils.substringBetween(files.stream().findFirst()
                 .orElseThrow(() -> {
-                    String message = "Scan files could not be found.";
+                    String message = "Could not find scan files.";
                     log.error(message);
                     return new FileNotFoundException(message);
                 }).getPath(), "/");

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ImportService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ImportService.java
@@ -5,6 +5,7 @@ import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants
 import com.solace.maas.ep.event.management.agent.plugin.processor.output.file.event.DataCollectionFileEvent;
 import com.solace.maas.ep.event.management.agent.repository.model.file.DataCollectionFileEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.route.RouteEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanEntity;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ImportRequestBO;
 import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileBO;
 import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDetailsBO;
@@ -26,6 +27,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -35,12 +37,14 @@ public class ImportService {
 
     private final ProducerTemplate producerTemplate;
     private final DataCollectionFileService dataCollectionFileService;
+    private final ScanService scanService;
     private final EventPortalProperties eventPortalProperties;
 
-    public ImportService(ProducerTemplate producerTemplate,
-                         DataCollectionFileService dataCollectionFileService, EventPortalProperties eventPortalProperties) {
+    public ImportService(ProducerTemplate producerTemplate, DataCollectionFileService dataCollectionFileService,
+                         ScanService scanService, EventPortalProperties eventPortalProperties) {
         this.producerTemplate = producerTemplate;
         this.dataCollectionFileService = dataCollectionFileService;
+        this.scanService = scanService;
         this.eventPortalProperties = eventPortalProperties;
     }
 
@@ -69,10 +73,18 @@ public class ImportService {
     }
 
     public InputStream zip(ZipRequestBO zipRequestBO) throws FileNotFoundException {
-        String messagingServiceId = zipRequestBO.getMessagingServiceId();
         String scanId = zipRequestBO.getScanId();
 
         List<DataCollectionFileEntity> files = dataCollectionFileService.findAllByScanId(scanId);
+
+        ScanEntity scanEntity = scanService.findById(scanId)
+                .orElseThrow(() -> {
+                    String message = String.format("Could not find scan : [%s].", scanId);
+                    log.error(message);
+                    return new NoSuchElementException(message);
+                });
+
+        String messagingServiceId = scanEntity.getMessagingService().getId();
 
         String scheduleId = StringUtils.substringBetween(files.stream().findFirst()
                 .orElseThrow(() -> {

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportControllerTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/scanManager/rest/DataImportControllerTests.java
@@ -62,7 +62,6 @@ public class DataImportControllerTests {
         DataImportController controller = new DataImportControllerImpl(importService);
 
         ZipRequestBO zipRequestBO = ZipRequestBO.builder()
-                .messagingServiceId("messagingServiceId")
                 .scanId("scanId")
                 .build();
 
@@ -70,7 +69,7 @@ public class DataImportControllerTests {
                 .thenReturn(mock(InputStream.class));
 
         ResponseEntity<InputStreamResource> reply =
-                controller.zip("messagingServiceId", "scanId");
+                controller.zip("scanId");
 
         assertThat(reply.getStatusCode()).isEqualTo(HttpStatus.OK);
 
@@ -84,7 +83,7 @@ public class DataImportControllerTests {
         DataImportController controller = new DataImportControllerImpl(importService);
 
         ResponseEntity<InputStreamResource> reply =
-                controller.zip("messagingServiceId", "scanId");
+                controller.zip("scanId");
 
         assertThat(reply.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ImportServiceTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ImportServiceTests.java
@@ -4,7 +4,9 @@ import com.solace.maas.ep.event.management.agent.TestConfig;
 import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
 import com.solace.maas.ep.event.management.agent.config.eventPortal.GatewayMessagingProperties;
 import com.solace.maas.ep.event.management.agent.config.eventPortal.GatewayProperties;
+import com.solace.maas.ep.event.management.agent.config.plugin.enumeration.MessagingServiceType;
 import com.solace.maas.ep.event.management.agent.repository.model.file.DataCollectionFileEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.mesagingservice.MessagingServiceEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanEntity;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ImportRequestBO;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ZipRequestBO;
@@ -31,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -57,6 +60,9 @@ public class ImportServiceTests {
 
     @Mock
     private DataCollectionFileService dataCollectionFileService;
+
+    @Mock
+    private ScanService scanService;
 
     @InjectMocks
     private ImportService importService;
@@ -102,7 +108,6 @@ public class ImportServiceTests {
     @Test
     public void testZipData() {
         ZipRequestBO zipRequestBO = ZipRequestBO.builder()
-                .messagingServiceId("service1")
                 .scanId("scanId")
                 .build();
 
@@ -112,9 +117,19 @@ public class ImportServiceTests {
                         .path("data_collection/" + UUID.randomUUID() + "/" + UUID.randomUUID() + "/topicListing.json")
                         .scan(ScanEntity.builder()
                                 .id(UUID.randomUUID().toString())
-//                                .scanType("KAFKA_ALL")
                                 .build())
                         .purged(false)
+                        .build()));
+
+        when(scanService.findById("scanId"))
+                .thenReturn(Optional.ofNullable(ScanEntity.builder()
+                        .id(UUID.randomUUID().toString())
+                        .emaId("emdId")
+                        .messagingService(MessagingServiceEntity.builder()
+                                .id(UUID.randomUUID().toString())
+                                .name("staging service")
+                                .type(MessagingServiceType.SOLACE.name())
+                                .build())
                         .build()));
 
         Path file = tempDir.resolve("test.json");


### PR DESCRIPTION
### What is the purpose of this change?

Simplify EMA's Data Import Controller zip endpoint.

### How was this change implemented?

The endpoint is simplified such that the `messagingServiceId` is removed and retrieved from the DB. The new endpoint is `/export/{scanId}/zip`

### How was this change tested?

Manual + Unit tests.

### Is there anything the reviewers should focus on/be aware of?
N/A
