### PR TITLE
Fix broken manual import by persisting the scan data into the DB during the import

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportParseMetaInfFileProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportParseMetaInfFileProcessor.java
@@ -22,6 +22,7 @@ public class ScanDataImportParseMetaInfFileProcessor implements Processor {
 
         exchange.getIn().setHeader(RouteConstants.SCAN_ID, metaInfFileBO.getScanId());
         exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, metaInfFileBO.getMessagingServiceId());
+        exchange.getIn().setHeader(RouteConstants.EVENT_MANAGEMENT_ID, metaInfFileBO.getEmaId());
         exchange.getIn().setHeader(RouteConstants.SCHEDULE_ID, metaInfFileBO.getScheduleId());
 
         List<MetaInfFileDetailsBO> filesDetails = metaInfFileBO.getFiles();

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPersistScanDataProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPersistScanDataProcessor.java
@@ -1,0 +1,117 @@
+package com.solace.maas.ep.event.management.agent.processor;
+
+import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
+import com.solace.maas.ep.event.management.agent.plugin.service.MessagingServiceDelegateService;
+import com.solace.maas.ep.event.management.agent.repository.model.file.DataCollectionFileEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.mesagingservice.MessagingServiceEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanStatusEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanTypeEntity;
+import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDetailsBO;
+import com.solace.maas.ep.event.management.agent.service.ScanService;
+import com.solace.maas.ep.event.management.agent.service.ScanTypeService;
+import com.solace.maas.ep.event.management.agent.util.IDGenerator;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Component
+public class ScanDataImportPersistScanDataProcessor implements Processor {
+
+    private final MessagingServiceDelegateService messagingServiceDelegateService;
+    private final ScanService scanService;
+    private final ScanTypeService scanTypeService;
+    private final IDGenerator idGenerator;
+
+    public ScanDataImportPersistScanDataProcessor(MessagingServiceDelegateService messagingServiceDelegateService,
+                                                  ScanService scanService, ScanTypeService scanTypeService,
+                                                  IDGenerator idGenerator) {
+        this.messagingServiceDelegateService = messagingServiceDelegateService;
+        this.scanService = scanService;
+        this.scanTypeService = scanTypeService;
+        this.idGenerator = idGenerator;
+    }
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        prepareAndSaveScanDetails(exchange);
+    }
+
+    private void prepareAndSaveScanDetails(Exchange exchange) {
+        String messagingServiceId = (String) exchange.getIn().getHeader(RouteConstants.MESSAGING_SERVICE_ID);
+        String emaId = (String) exchange.getIn().getHeader(RouteConstants.EVENT_MANAGEMENT_ID);
+        String scanId = (String) exchange.getIn().getHeader(RouteConstants.SCAN_ID);
+        String scheduleId = (String) exchange.getIn().getHeader(RouteConstants.SCHEDULE_ID);
+        String scanType = (String) exchange.getIn().getHeader(RouteConstants.SCAN_TYPE);
+
+        List<?> files = (List<?>) exchange.getIn().getBody();
+
+        MessagingServiceEntity messagingServiceEntity =
+                messagingServiceDelegateService.getMessagingServiceById(messagingServiceId);
+
+        ScanEntity scanEntity = ScanEntity.builder()
+                .id(scanId)
+                .messagingService(messagingServiceEntity)
+                .emaId(emaId)
+                .build();
+
+        List<DataCollectionFileEntity> fileEntities = prepareFiles(scanEntity, files, scheduleId, scanId);
+
+        scanEntity.setDataCollectionFiles(fileEntities);
+
+        ScanEntity savedScan = scanService.save(scanEntity);
+
+        prepareAndSaveScanTypes(savedScan, scanType);
+    }
+
+    private List<DataCollectionFileEntity> prepareFiles(ScanEntity scanEntity, List<?> metaInfFileDetailsBOS,
+                                                        String scheduleId, String scanId) {
+        List<String> files = metaInfFileDetailsBOS.stream()
+                .map(MetaInfFileDetailsBO.class::cast)
+                .map(MetaInfFileDetailsBO::getFileName)
+                .collect(Collectors.toUnmodifiableList());
+
+        return files.stream()
+                .map(fileEntity ->
+                        DataCollectionFileEntity.builder()
+                                .path("data_collection/" + scheduleId + "/" + scanId + "/" + fileEntity)
+                                .purged(false)
+                                .scan(scanEntity)
+                                .build())
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    private void prepareAndSaveScanTypes(ScanEntity savedScan, String scanType) {
+        List<String> scanTypes = Arrays.stream(StringUtils.split(scanType, ","))
+                .collect(Collectors.toUnmodifiableList());
+
+        List<ScanTypeEntity> scanTypeEntities = scanTypes.stream().map(type ->
+                        ScanTypeEntity.builder()
+                                .id(idGenerator.generateRandomUniqueId())
+                                .name(type)
+                                .scan(savedScan)
+                                .build())
+                .collect(Collectors.toUnmodifiableList());
+
+        List<ScanStatusEntity> importStatuses = scanTypes.stream().map(type ->
+                        ScanStatusEntity.builder()
+                                .id(idGenerator.generateRandomUniqueId())
+                                .status(ScanStatus.IN_PROGRESS.name())
+                                .build())
+                .collect(Collectors.toUnmodifiableList());
+
+        IntStream.range(0, importStatuses.size()).forEach(i -> {
+            importStatuses.get(i).setScanType(scanTypeEntities.get(i));
+            scanTypeEntities.get(i).setStatus(importStatuses.get(i));
+        });
+
+        scanTypeService.saveAll(scanTypeEntities);
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPersistScanFilesProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPersistScanFilesProcessor.java
@@ -1,8 +1,11 @@
 package com.solace.maas.ep.event.management.agent.processor;
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
-import com.solace.maas.ep.event.management.agent.repository.manualimport.ManualImportRepository;
 import com.solace.maas.ep.event.management.agent.repository.model.manualimport.ManualImportEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanTypeEntity;
+import com.solace.maas.ep.event.management.agent.service.ManualImportService;
+import com.solace.maas.ep.event.management.agent.service.ScanTypeService;
+import com.solace.maas.ep.event.management.agent.util.IDGenerator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
@@ -15,10 +18,16 @@ import java.util.Map;
 @Component
 @ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
 public class ScanDataImportPersistScanFilesProcessor implements Processor {
-    private final ManualImportRepository manualImportRepository;
 
-    public ScanDataImportPersistScanFilesProcessor(ManualImportRepository manualImportRepository) {
-        this.manualImportRepository = manualImportRepository;
+    private final ScanTypeService scanTypeService;
+    private final ManualImportService manualImportService;
+    private final IDGenerator idGenerator;
+
+    public ScanDataImportPersistScanFilesProcessor(ScanTypeService scanTypeService, ManualImportService manualImportService,
+                                                   IDGenerator idGenerator) {
+        this.scanTypeService = scanTypeService;
+        this.manualImportService = manualImportService;
+        this.idGenerator = idGenerator;
     }
 
     @Override
@@ -32,17 +41,16 @@ public class ScanDataImportPersistScanFilesProcessor implements Processor {
 
         log.trace("reading file: {}", fileName);
 
+        ScanTypeEntity scanTypeEntity = scanTypeService.findByNameAndScanId(scanType, scanId)
+                .orElseThrow(() -> new RuntimeException("Can't apply Scan Status to Scan that doesn't exist!"));
+
         ManualImportEntity manualImportEntity = ManualImportEntity.builder()
+                .id(idGenerator.generateRandomUniqueId())
                 .fileName(fileName)
                 .groupId(groupId)
-                .scanId(scanId)
-                .scanType(scanType)
+                .scanType(scanTypeEntity)
                 .build();
 
-        save(manualImportEntity);
-    }
-
-    private void save(ManualImportEntity manualImportEntity) {
-        manualImportRepository.save(manualImportEntity);
+        manualImportService.save(manualImportEntity);
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/manualimport/ManualImportEntity.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/manualimport/ManualImportEntity.java
@@ -1,17 +1,21 @@
 package com.solace.maas.ep.event.management.agent.repository.model.manualimport;
 
 import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanTypeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.GenericGenerator;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
+import java.io.Serializable;
 
 @ExcludeFromJacocoGeneratedReport
 @AllArgsConstructor
@@ -20,33 +24,18 @@ import javax.persistence.Table;
 @Builder
 @Table(name = "MANUAL_IMPORT")
 @Entity
-public class ManualImportEntity {
+public class ManualImportEntity implements Serializable {
     @Id
-    @GeneratedValue(generator = "uuid2")
-    @GenericGenerator(name = "uuid2", strategy = "org.hibernate.id.UUIDGenerator")
     @Column(name = "ID")
     private String id;
 
-    @Column(name = "FILE_PATH")
+    @Column(name = "FILE_NAME")
     private String fileName;
 
     @Column(name = "SCHEDULE_ID")
     private String groupId;
 
-    @Column(name = "SCAN_ID")
-    private String scanId;
-
-    @Column(name = "SCAN_TYPE")
-    private String scanType;
-
-    @Override
-    public String toString() {
-        return "ManualImportEntity{" +
-                "id='" + id + '\'' +
-                ", groupId='" + groupId + '\'' +
-                ", scanId='" + scanId + '\'' +
-                ", scanType='" + scanType + '\'' +
-                ", fileName='" + fileName + '\'' +
-                '}';
-    }
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE, optional = false)
+    @JoinColumn(name = "SCAN_TYPE_ID", referencedColumnName = "ID", nullable = false)
+    private ScanTypeEntity scanType;
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/mesagingservice/MessagingServiceEntity.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/mesagingservice/MessagingServiceEntity.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -32,9 +33,11 @@ public class MessagingServiceEntity implements Serializable {
     @Column(name = "MESSAGING_SERVICE_TYPE", nullable = false)
     private String type;
 
+    @ToString.Exclude
     @OneToMany(mappedBy = "messagingService", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ConnectionDetailsEntity> connections;
 
+    @ToString.Exclude
     @OneToMany(mappedBy = "messagingService", fetch = FetchType.LAZY, cascade = CascadeType.MERGE)
     private List<ScanEntity> scanEntities;
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/scan/ScanStatusEntity.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/scan/ScanStatusEntity.java
@@ -5,13 +5,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.GenericGenerator;
+import lombok.ToString;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
@@ -27,11 +26,10 @@ import java.io.Serializable;
 @Entity
 public class ScanStatusEntity implements Serializable {
     @Id
-    @GeneratedValue(generator = "uuid2")
-    @GenericGenerator(name = "uuid2", strategy = "org.hibernate.id.UUIDGenerator")
     @Column(name = "ID")
     private String id;
 
+    @ToString.Exclude
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE, optional = false)
     @JoinColumn(name = "SCAN_TYPE_ID", referencedColumnName = "ID", nullable = false)
     private ScanTypeEntity scanType;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/scan/ScanTypeEntity.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/scan/ScanTypeEntity.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.CascadeType;
@@ -35,10 +36,12 @@ public class ScanTypeEntity implements Serializable {
     @Column(name = "NAME", nullable = false)
     private String name;
 
+    @ToString.Exclude
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE, optional = false)
     @JoinColumn(name = "SCAN_ID", referencedColumnName = "ID", nullable = false)
     private ScanEntity scan;
 
+    @ToString.Exclude
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE, mappedBy = "scanType")
     private ScanStatusEntity status;
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/aggregation/FileParseAggregationStrategy.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/ep/aggregation/FileParseAggregationStrategy.java
@@ -12,6 +12,8 @@ public class FileParseAggregationStrategy implements AggregationStrategy {
     public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
         newExchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID,
                 oldExchange.getIn().getHeader(RouteConstants.MESSAGING_SERVICE_ID));
+        newExchange.getIn().setHeader(RouteConstants.EVENT_MANAGEMENT_ID,
+                oldExchange.getIn().getHeader(RouteConstants.EVENT_MANAGEMENT_ID));
         newExchange.getIn().setHeader(RouteConstants.SCAN_ID,
                 oldExchange.getIn().getHeader(RouteConstants.SCAN_ID));
         newExchange.getIn().setHeader(RouteConstants.SCHEDULE_ID,

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseMetaInfFileRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseMetaInfFileRouteBuilder.java
@@ -2,6 +2,7 @@ package com.solace.maas.ep.event.management.agent.route.manualImport;
 
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportOverAllStatusProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportParseMetaInfFileProcessor;
+import com.solace.maas.ep.event.management.agent.processor.ScanDataImportPersistScanDataProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportPublishImportScanEventProcessor;
 import com.solace.maas.ep.event.management.agent.route.ep.exceptionhandlers.ScanDataImportExceptionHandler;
 import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileBO;
@@ -18,13 +19,16 @@ public class ScanDataImportParseMetaInfFileRouteBuilder extends RouteBuilder {
     private final ScanDataImportParseMetaInfFileProcessor scanDataImportParseMetaInfFileProcessor;
     private final ScanDataImportOverAllStatusProcessor scanDataImportOverAllStatusProcessor;
     private final ScanDataImportPublishImportScanEventProcessor scanDataImportPublishImportScanEventProcessor;
+    private final ScanDataImportPersistScanDataProcessor scanDataImportPersistScanDataProcessor;
 
     public ScanDataImportParseMetaInfFileRouteBuilder(ScanDataImportParseMetaInfFileProcessor scanDataImportParseMetaInfFileProcessor,
                                                       ScanDataImportOverAllStatusProcessor scanDataImportOverAllStatusProcessor,
-                                                      ScanDataImportPublishImportScanEventProcessor scanDataImportPublishImportScanEventProcessor) {
+                                                      ScanDataImportPublishImportScanEventProcessor scanDataImportPublishImportScanEventProcessor,
+                                                      ScanDataImportPersistScanDataProcessor scanDataImportPersistScanDataProcessor) {
         this.scanDataImportParseMetaInfFileProcessor = scanDataImportParseMetaInfFileProcessor;
         this.scanDataImportOverAllStatusProcessor = scanDataImportOverAllStatusProcessor;
         this.scanDataImportPublishImportScanEventProcessor = scanDataImportPublishImportScanEventProcessor;
+        this.scanDataImportPersistScanDataProcessor = scanDataImportPersistScanDataProcessor;
     }
 
     @Override
@@ -49,6 +53,7 @@ public class ScanDataImportParseMetaInfFileRouteBuilder extends RouteBuilder {
         from("direct:sendOverAllInProgressImportStatus")
                 .routeId("sendOverAllInProgressImportStatus")
                 .process(scanDataImportOverAllStatusProcessor)
+                .process(scanDataImportPersistScanDataProcessor)
                 .to("direct:overallScanStatusPublisher?block=false&failIfNoConsumers=false");
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/model/MetaInfFileBO.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/scanManager/model/MetaInfFileBO.java
@@ -21,6 +21,8 @@ public class MetaInfFileBO implements Serializable {
 
     private String messagingServiceId;
 
+    private String emaId;
+
     private String scheduleId;
 
     private String scanId;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ImportService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ImportService.java
@@ -86,6 +86,8 @@ public class ImportService {
 
         String messagingServiceId = scanEntity.getMessagingService().getId();
 
+        String emaId = scanEntity.getEmaId();
+
         String scheduleId = StringUtils.substringBetween(files.stream().findFirst()
                 .orElseThrow(() -> {
                     String message = "Could not find scan files.";
@@ -93,7 +95,7 @@ public class ImportService {
                     return new FileNotFoundException(message);
                 }).getPath(), "/");
 
-        MetaInfFileBO metaInfJson = prepareMetaInfJson(files, messagingServiceId, scheduleId, scanId);
+        MetaInfFileBO metaInfJson = prepareMetaInfJson(files, messagingServiceId, emaId, scheduleId, scanId);
 
         List<DataCollectionFileEvent> fileEvents = prepareFileEvents(files, scanId);
 
@@ -107,7 +109,7 @@ public class ImportService {
     }
 
     private MetaInfFileBO prepareMetaInfJson(List<DataCollectionFileEntity> files, String messagingServiceId,
-                                             String scheduleId, String scanId) {
+                                             String emaId, String scheduleId, String scanId) {
 
         List<MetaInfFileDetailsBO> metaInfFileDetailsBOFiles = new ArrayList<>();
         files.forEach(file -> {
@@ -128,6 +130,7 @@ public class ImportService {
                 .scheduleId(scheduleId)
                 .scanId(scanId)
                 .messagingServiceId(messagingServiceId)
+                .emaId(emaId)
                 .build();
     }
 

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ManualImportService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ManualImportService.java
@@ -1,0 +1,18 @@
+package com.solace.maas.ep.event.management.agent.service;
+
+import com.solace.maas.ep.event.management.agent.repository.manualimport.ManualImportRepository;
+import com.solace.maas.ep.event.management.agent.repository.model.manualimport.ManualImportEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ManualImportService {
+    private final ManualImportRepository manualImportRepository;
+
+    public ManualImportService(ManualImportRepository manualImportRepository) {
+        this.manualImportRepository = manualImportRepository;
+    }
+
+    public ManualImportEntity save(ManualImportEntity manualImportEntity) {
+        return manualImportRepository.save(manualImportEntity);
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/MessagingServiceDelegateServiceImpl.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/MessagingServiceDelegateServiceImpl.java
@@ -70,6 +70,7 @@ public class MessagingServiceDelegateServiceImpl implements MessagingServiceDele
      * @return The retrieved Messaging Service.
      */
     @SuppressWarnings("unchecked")
+    @Override
     @Transactional
     public MessagingServiceEntity getMessagingServiceById(String messagingServiceId) {
         Optional<MessagingServiceEntity> messagingServiceEntityOpt = repository.findById(messagingServiceId);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanService.java
@@ -12,8 +12,8 @@ import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanDesti
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanRecipientEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanRecipientHierarchyEntity;
-import com.solace.maas.ep.event.management.agent.repository.scan.ScanRecipientHierarchyRepository;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanTypeEntity;
+import com.solace.maas.ep.event.management.agent.repository.scan.ScanRecipientHierarchyRepository;
 import com.solace.maas.ep.event.management.agent.repository.scan.ScanRepository;
 import com.solace.maas.ep.event.management.agent.repository.scan.ScanTypeRepository;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ScanItemBO;
@@ -308,7 +308,7 @@ public class ScanService {
      * @param scanEntity The information of the Messaging Service scan.
      * @return The saved Messaging Service scan details.
      */
-    protected ScanEntity save(ScanEntity scanEntity) {
+    public ScanEntity save(ScanEntity scanEntity) {
         return repository.save(scanEntity);
     }
 

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanStatusService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanStatusService.java
@@ -4,6 +4,7 @@ import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanStatusEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanTypeEntity;
 import com.solace.maas.ep.event.management.agent.repository.scan.ScanStatusRepository;
+import com.solace.maas.ep.event.management.agent.util.IDGenerator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,9 +16,12 @@ public class ScanStatusService {
 
     private final ScanTypeService scanTypeService;
 
-    public ScanStatusService(ScanStatusRepository repository, ScanTypeService scanTypeService) {
+    private final IDGenerator idGenerator;
+
+    public ScanStatusService(ScanStatusRepository repository, ScanTypeService scanTypeService, IDGenerator idGenerator) {
         this.repository = repository;
         this.scanTypeService = scanTypeService;
+        this.idGenerator = idGenerator;
     }
 
     @Transactional
@@ -27,10 +31,11 @@ public class ScanStatusService {
 
         ScanStatusEntity scanStatusEntity = scanType.getStatus();
 
-        if(Objects.nonNull(scanStatusEntity)) {
+        if (Objects.nonNull(scanStatusEntity)) {
             scanStatusEntity.setStatus(ScanStatus.COMPLETE.name());
         } else {
             scanStatusEntity = ScanStatusEntity.builder()
+                    .id(idGenerator.generateRandomUniqueId())
                     .scanType(scanType)
                     .status(ScanStatus.COMPLETE.name())
                     .build();

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanTypeService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanTypeService.java
@@ -4,6 +4,7 @@ import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanTypeE
 import com.solace.maas.ep.event.management.agent.repository.scan.ScanTypeRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -20,5 +21,9 @@ public class ScanTypeService {
 
     public Optional<ScanTypeEntity> findByNameAndScanId(String name, String scanId) {
         return repository.findByNameAndScanId(name, scanId);
+    }
+
+    public Iterable<ScanTypeEntity> saveAll(List<ScanTypeEntity> scanTypeEntities) {
+        return repository.saveAll(scanTypeEntities);
     }
 }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanDataImportParseMetaInfFileRouteBuilderTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanDataImportParseMetaInfFileRouteBuilderTests.java
@@ -3,6 +3,7 @@ package com.solace.maas.ep.event.management.agent.plugin.route.handler;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportOverAllStatusProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportParseMetaInfFileProcessor;
+import com.solace.maas.ep.event.management.agent.processor.ScanDataImportPersistScanDataProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportPublishImportScanEventProcessor;
 import com.solace.maas.ep.event.management.agent.route.manualImport.ScanDataImportParseMetaInfFileRouteBuilder;
 import lombok.SneakyThrows;
@@ -105,9 +106,11 @@ public class ScanDataImportParseMetaInfFileRouteBuilderTests {
                     = mock(ScanDataImportOverAllStatusProcessor.class);
             ScanDataImportPublishImportScanEventProcessor scanDataImportPublishProcessor
                     = mock(ScanDataImportPublishImportScanEventProcessor.class);
+            ScanDataImportPersistScanDataProcessor scanDataImportPersistScanDataProcessor
+                    = mock(ScanDataImportPersistScanDataProcessor.class);
 
             return new ScanDataImportParseMetaInfFileRouteBuilder(scanDataImportParseMetaInfFileProcessor,
-                    scanDataImportOverAllStatusProcessor, scanDataImportPublishProcessor);
+                    scanDataImportOverAllStatusProcessor, scanDataImportPublishProcessor, scanDataImportPersistScanDataProcessor);
         }
 
         public static String getMetaInfJson() throws JSONException {

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPersistScanDataProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPersistScanDataProcessorTests.java
@@ -1,0 +1,117 @@
+package com.solace.maas.ep.event.management.agent.processor;
+
+import com.solace.maas.ep.event.management.agent.TestConfig;
+import com.solace.maas.ep.event.management.agent.config.plugin.enumeration.MessagingServiceType;
+import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.repository.model.mesagingservice.MessagingServiceEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanTypeEntity;
+import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDetailsBO;
+import com.solace.maas.ep.event.management.agent.service.MessagingServiceDelegateServiceImpl;
+import com.solace.maas.ep.event.management.agent.service.ScanService;
+import com.solace.maas.ep.event.management.agent.service.ScanTypeService;
+import com.solace.maas.ep.event.management.agent.util.IDGenerator;
+import lombok.SneakyThrows;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("TEST")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
+public class ScanDataImportPersistScanDataProcessorTests {
+
+    @Autowired
+    CamelContext camelContext;
+
+    @Mock
+    MessagingServiceDelegateServiceImpl messagingServiceDelegateService;
+
+    @Mock
+    ScanService scanService;
+
+    @Mock
+    ScanTypeService scanTypeService;
+
+    @Mock
+    IDGenerator idGenerator;
+
+    @InjectMocks
+    ScanDataImportPersistScanDataProcessor scanDataImportPersistScanDataProcessor;
+
+    @SneakyThrows
+    @Test
+    public void testScanDataImportPersistScanDataProcessor() {
+        String groupId = UUID.randomUUID().toString();
+        String scanId = "sanId";
+        String emaId = "emaId";
+        String scanType = "queueConfiguration,queueListing,subscriptionConfiguration";
+
+
+//        messagingServiceId "d8i99kj5qzj"
+//        emaId "5lcf7wa5jpu"
+//        scheduleId "07a075f4-29a3-4387-8fb5-8644c8fff5d3"
+//        scanId "xtfz7xyewma"
+
+        List<MetaInfFileDetailsBO> fileDetailsBOS = List.of(
+                MetaInfFileDetailsBO.builder()
+                        .fileName("queueConfiguration.json")
+                        .dataEntityType("queueConfiguration").build(),
+                MetaInfFileDetailsBO.builder()
+                        .fileName("queueListing.json")
+                        .dataEntityType("queueListing").build(),
+                MetaInfFileDetailsBO.builder()
+                        .fileName("subscriptionConfiguration.json")
+                        .dataEntityType("subscriptionConfiguration").build());
+
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.getIn().setHeader(RouteConstants.SCAN_ID, scanId);
+        exchange.getIn().setHeader(RouteConstants.EVENT_MANAGEMENT_ID, emaId);
+        exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, scanType);
+        exchange.getIn().setHeader(RouteConstants.SCHEDULE_ID, groupId);
+        exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, "messagingServiceId");
+
+        exchange.getIn().setBody(fileDetailsBOS);
+
+        MessagingServiceEntity messagingServiceEntity = MessagingServiceEntity.builder()
+                .id("messagingServiceId")
+                .name("staging service")
+                .type(MessagingServiceType.SOLACE.name())
+                .connections(List.of())
+                .build();
+
+        when(messagingServiceDelegateService.getMessagingServiceById("messagingServiceId"))
+                .thenReturn(messagingServiceEntity);
+
+        when(idGenerator.generateRandomUniqueId())
+                .thenReturn("abc123");
+
+        when(scanTypeService.saveAll(any(List.class)))
+                .thenReturn(List.of(ScanTypeEntity.builder().build()));
+
+        when(scanService.save(any(ScanEntity.class)))
+                .thenReturn(ScanEntity.builder()
+                        .id(scanId)
+                        .emaId("emaId")
+                        .messagingService(messagingServiceEntity)
+                        .createdAt(Instant.now())
+                        .build());
+
+        scanDataImportPersistScanDataProcessor.process(exchange);
+
+        assertThatNoException();
+    }
+}

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportScanFilesProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportScanFilesProcessorTests.java
@@ -2,25 +2,30 @@ package com.solace.maas.ep.event.management.agent.processor;
 
 import com.solace.maas.ep.event.management.agent.TestConfig;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
-import com.solace.maas.ep.event.management.agent.repository.manualimport.ManualImportRepository;
+import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
 import com.solace.maas.ep.event.management.agent.repository.model.manualimport.ManualImportEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanStatusEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanTypeEntity;
+import com.solace.maas.ep.event.management.agent.service.ManualImportService;
+import com.solace.maas.ep.event.management.agent.service.ScanTypeService;
 import com.solace.maas.ep.event.management.agent.util.IDGenerator;
 import lombok.SneakyThrows;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.support.DefaultExchange;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -28,17 +33,17 @@ import static org.mockito.Mockito.when;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
 public class ScanDataImportScanFilesProcessorTests {
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @Mock
-    ManualImportRepository manualImportRepository;
-
     @Autowired
     CamelContext camelContext;
 
-    @Autowired
+    @Mock
     IDGenerator idGenerator;
+
+    @Mock
+    ScanTypeService scanTypeService;
+
+    @Mock
+    ManualImportService manualImportService;
 
     @InjectMocks
     ScanDataImportPersistScanFilesProcessor scanDataImportFileProcessor;
@@ -47,7 +52,7 @@ public class ScanDataImportScanFilesProcessorTests {
     @Test
     public void testScanDataImportScanFilesProcessor() {
         String groupId = UUID.randomUUID().toString();
-        String scanId = idGenerator.generateRandomUniqueId();
+        String scanId = "sanId";
         String scanType = "subscriptionConfiguration";
         String fileName = "data/" + groupId + "/" + scanId + "/" + scanType + ".json";
 
@@ -59,16 +64,53 @@ public class ScanDataImportScanFilesProcessorTests {
         exchange.getIn().setHeader("CamelFileName", fileName);
         exchange.getIn().setBody("test exchange");
 
-        when(manualImportRepository.save(any(ManualImportEntity.class)))
+        when(idGenerator.generateRandomUniqueId())
+                .thenReturn("abc123");
+
+        when(scanTypeService.findByNameAndScanId(any(String.class), any(String.class)))
+                .thenReturn(Optional.ofNullable(ScanTypeEntity.builder()
+                        .status(ScanStatusEntity.builder()
+                                .status(ScanStatus.IN_PROGRESS.name())
+                                .build())
+                        .build()));
+
+        when(manualImportService.save(any(ManualImportEntity.class)))
                 .thenReturn(ManualImportEntity.builder().build());
 
         scanDataImportFileProcessor.process(exchange);
 
         assertThatNoException();
+    }
 
+    @SneakyThrows
+    @Test
+    public void testScanDataImportScanFilesProcessorException() {
+        Exchange exchange = new DefaultExchange(camelContext);
         exchange.setProperty(Exchange.EXCEPTION_CAUGHT, new Exception());
-        scanDataImportFileProcessor.process(exchange);
 
-        exception.expect(Exception.class);
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> scanDataImportFileProcessor.process(exchange));
+
+        assertTrue(thrown.getMessage().contains("Can't apply Scan Status to Scan that doesn't exist!"));
+    }
+
+    @SneakyThrows
+    @Test
+    public void testScanDataImportScanFilesProcessorWithNoScanType() {
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.getIn().setHeader(RouteConstants.SCAN_ID, "scanId");
+        exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, "scanType");
+        exchange.getIn().setHeader(RouteConstants.SCHEDULE_ID, "groupId");
+        exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, "messagingServiceId");
+        exchange.getIn().setHeader("CamelFileName", "fileName");
+        exchange.getIn().setBody("test exchange");
+
+        when(scanTypeService.findByNameAndScanId(any(String.class), any(String.class)))
+                .thenReturn(Optional.empty());
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> scanDataImportFileProcessor.process(exchange));
+
+        assertTrue(thrown.getMessage().contentEquals("Can't apply Scan Status to Scan that doesn't exist!"));
     }
 }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ManualImportServiceTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ManualImportServiceTests.java
@@ -1,0 +1,48 @@
+package com.solace.maas.ep.event.management.agent.service;
+
+import com.solace.maas.ep.event.management.agent.TestConfig;
+import com.solace.maas.ep.event.management.agent.repository.manualimport.ManualImportRepository;
+import com.solace.maas.ep.event.management.agent.repository.model.manualimport.ManualImportEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanTypeEntity;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("TEST")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
+public class ManualImportServiceTests {
+
+    @Mock
+    private ManualImportRepository manualImportRepository;
+
+    @InjectMocks
+    private ManualImportService manualImportService;
+
+    @SneakyThrows
+    @Test
+    public void testSave() {
+        ManualImportEntity manualImportEntity = ManualImportEntity.builder()
+                .id(UUID.randomUUID().toString())
+                .groupId(UUID.randomUUID().toString())
+                .fileName("queueListing.json")
+                .scanType(ScanTypeEntity.builder().build())
+                .build();
+
+        when(manualImportRepository.save(any(ManualImportEntity.class)))
+                .thenReturn(manualImportEntity);
+
+        ManualImportEntity result = manualImportService.save(manualImportEntity);
+
+        assertThat(result.getId()).isEqualTo(manualImportEntity.getId());
+        assertThat(result.getFileName()).isEqualTo(manualImportEntity.getFileName());
+    }
+}

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ScanStatusServiceTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ScanStatusServiceTests.java
@@ -1,0 +1,80 @@
+package com.solace.maas.ep.event.management.agent.service;
+
+import com.solace.maas.ep.event.management.agent.TestConfig;
+import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanStatusEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanTypeEntity;
+import com.solace.maas.ep.event.management.agent.repository.scan.ScanStatusRepository;
+import com.solace.maas.ep.event.management.agent.util.IDGenerator;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("TEST")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
+public class ScanStatusServiceTests {
+
+    @Mock
+    ScanTypeService scanTypeService;
+
+    @Mock
+    ScanStatusRepository scanStatusRepository;
+
+    @Mock
+    IDGenerator idGenerator;
+
+    @InjectMocks
+    private ScanStatusService scanStatusService;
+
+    @SneakyThrows
+    @Test
+    public void testSaveWithScanStatus() {
+        when(scanTypeService.findByNameAndScanId(any(String.class), any(String.class)))
+                .thenReturn(Optional.ofNullable(ScanTypeEntity.builder()
+                        .id("abc123")
+                        .name("queueListing")
+                        .scan(ScanEntity.builder().build())
+                        .status(ScanStatusEntity.builder()
+                                .status(ScanStatus.IN_PROGRESS.name())
+                                .build())
+                        .build()));
+
+        when(scanStatusRepository.save(any(ScanStatusEntity.class)))
+                .thenReturn(ScanStatusEntity.builder().build());
+
+        scanStatusService.save("name", "scanId");
+
+        assertThatNoException();
+    }
+
+    @SneakyThrows
+    @Test
+    public void testSaveWithoutScanStatus() {
+        when(scanTypeService.findByNameAndScanId(any(String.class), any(String.class)))
+                .thenReturn(Optional.ofNullable(ScanTypeEntity.builder()
+                        .id("abc123")
+                        .name("queueListing")
+                        .scan(ScanEntity.builder().build())
+                        .build()));
+
+        when(idGenerator.generateRandomUniqueId())
+                .thenReturn("abc123");
+
+        when(scanStatusRepository.save(any(ScanStatusEntity.class)))
+                .thenReturn(ScanStatusEntity.builder().build());
+
+        scanStatusService.save("name", "scanId");
+
+        assertThatNoException();
+    }
+}

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
@@ -19,6 +19,8 @@ public class RouteConstants {
 
     public static final String MESSAGING_SERVICE_ID = "MESSAGING_SERVICE_ID";
 
+    public static final String EVENT_MANAGEMENT_ID = "EVENT_MANAGEMENT_ID";
+
     public static final String IS_DATA_IMPORT = "IS_DATA_IMPORT";
 
     public static final String GENERAL_STATUS_MESSAGE = "GENERAL_STATUS_MESSAGE";

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/service/MessagingServiceDelegateService.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/service/MessagingServiceDelegateService.java
@@ -1,5 +1,7 @@
 package com.solace.maas.ep.event.management.agent.plugin.service;
 
 public interface MessagingServiceDelegateService {
+    <T> T getMessagingServiceById(String messagingServiceId);
+
     <T> T getMessagingServiceClient(String messagingServiceId);
 }


### PR DESCRIPTION
### What is the purpose of this change?

Fix the manual import

### How was this change implemented?

By introducing the `ScanDataImportPersistScanDataProcessor` that persists the scan info into the DB. Also, by updating other processors such as `ScanDataImportPersistScanFilesProcessor.` and `ScanDataImportParseMetaInfFileProcessor` and other related files.

### How was this change tested?

Manual + Unit tests

### Is there anything the reviewers should focus on/be aware of?

Currently, there is no mechanism to handle multiple imports of the same zip file.

**Note:** I've added the `@ToString.Exclude` to exclude some entities that have bidirectional relationships from the toString method. This is to avoid the `Unable to evaluate the expression Method threw 'java.lang.StackOverflowError' exception.` while keeping the `@Data` annotation.