### PR TITLE
DATAGO-50557: add handshake for EMA maualImport

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataImportMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataImportMessage.java
@@ -7,6 +7,8 @@ import com.solace.maas.ep.event.management.agent.plugin.mop.MOPUHFlag;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.util.List;
+
 @EqualsAndHashCode(callSuper = true)
 @Data
 public class ScanDataImportMessage extends MOPMessage {
@@ -16,7 +18,18 @@ public class ScanDataImportMessage extends MOPMessage {
 
     String messagingServiceId;
 
-    public ScanDataImportMessage(String orgId, String scanId, String messagingServiceId) {
+    private List<String> scanTypes;
+
+    private String emaId;
+
+    private String scheduleId;
+
+    public ScanDataImportMessage() {
+        super();
+    }
+
+    public ScanDataImportMessage(String orgId, String scanId, String messagingServiceId, List<String> scanTypes,
+                                 String emaId, String scheduleId) {
         super();
         withMessageType(MOPMessageType.generic)
                 .withProtocol(MOPProtocol.event)
@@ -26,5 +39,8 @@ public class ScanDataImportMessage extends MOPMessage {
         this.orgId = orgId;
         this.scanId = scanId;
         this.messagingServiceId = messagingServiceId;
+        this.scanTypes = scanTypes;
+        this.emaId = emaId;
+        this.scheduleId = scheduleId;
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataImportMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataImportMessage.java
@@ -20,16 +20,11 @@ public class ScanDataImportMessage extends MOPMessage {
 
     private List<String> scanTypes;
 
-    private String emaId;
-
-    private String scheduleId;
-
     public ScanDataImportMessage() {
         super();
     }
 
-    public ScanDataImportMessage(String orgId, String scanId, String messagingServiceId, List<String> scanTypes,
-                                 String emaId, String scheduleId) {
+    public ScanDataImportMessage(String orgId, String scanId, String messagingServiceId, List<String> scanTypes) {
         super();
         withMessageType(MOPMessageType.generic)
                 .withProtocol(MOPProtocol.event)
@@ -40,7 +35,5 @@ public class ScanDataImportMessage extends MOPMessage {
         this.scanId = scanId;
         this.messagingServiceId = messagingServiceId;
         this.scanTypes = scanTypes;
-        this.emaId = emaId;
-        this.scheduleId = scheduleId;
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataImportMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataImportMessage.java
@@ -18,13 +18,15 @@ public class ScanDataImportMessage extends MOPMessage {
 
     String messagingServiceId;
 
+    String runtimeAgentId;
+
     private List<String> scanTypes;
 
     public ScanDataImportMessage() {
         super();
     }
 
-    public ScanDataImportMessage(String orgId, String scanId, String messagingServiceId, List<String> scanTypes) {
+    public ScanDataImportMessage(String orgId, String scanId, String messagingServiceId, List<String> scanTypes, String runtimeAgentId) {
         super();
         withMessageType(MOPMessageType.generic)
                 .withProtocol(MOPProtocol.event)
@@ -35,5 +37,6 @@ public class ScanDataImportMessage extends MOPMessage {
         this.scanId = scanId;
         this.messagingServiceId = messagingServiceId;
         this.scanTypes = scanTypes;
+        this.runtimeAgentId = runtimeAgentId;
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportOverAllStatusProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportOverAllStatusProcessor.java
@@ -2,16 +2,11 @@ package com.solace.maas.ep.event.management.agent.processor;
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.constants.ScanStatus;
-import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDetailsBO;
 import lombok.extern.slf4j.Slf4j;
-import net.logstash.logback.encoder.org.apache.commons.lang3.StringUtils;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @SuppressWarnings("unchecked")
 @Slf4j
@@ -21,10 +16,7 @@ public class ScanDataImportOverAllStatusProcessor implements Processor {
 
     @Override
     public void process(Exchange exchange) throws Exception {
-        List<MetaInfFileDetailsBO> files = (List<MetaInfFileDetailsBO>) exchange.getIn().getBody();
-        List<String> scanTypes = files.stream().map(MetaInfFileDetailsBO::getDataEntityType).collect(Collectors.toUnmodifiableList());
 
         exchange.getIn().setHeader(RouteConstants.SCAN_STATUS, ScanStatus.IN_PROGRESS);
-        exchange.getIn().setHeader(RouteConstants.SCAN_TYPE, StringUtils.join(scanTypes,","));
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPersistFilePathsProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPersistFilePathsProcessor.java
@@ -1,0 +1,62 @@
+package com.solace.maas.ep.event.management.agent.processor;
+
+import com.solace.maas.ep.event.management.agent.repository.model.manualimport.ManualImportFilesEntity;
+import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDetailsBO;
+import com.solace.maas.ep.event.management.agent.service.ManualImportFilesService;
+import com.solace.maas.ep.event.management.agent.util.IDGenerator;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.EVENT_MANAGEMENT_ID;
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.IMPORT_ID;
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.SCAN_ID;
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.SCHEDULE_ID;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
+public class ScanDataImportPersistFilePathsProcessor implements Processor {
+
+    private final ManualImportFilesService manualImportFilesService;
+    private final IDGenerator idGenerator;
+
+    public ScanDataImportPersistFilePathsProcessor(ManualImportFilesService manualImportFilesService,
+                                                   IDGenerator idGenerator) {
+        this.manualImportFilesService = manualImportFilesService;
+        this.idGenerator = idGenerator;
+    }
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+
+        List<MetaInfFileDetailsBO> files = (List<MetaInfFileDetailsBO>) exchange.getIn().getBody();
+
+        Map<String, Object> properties = exchange.getIn().getHeaders();
+
+        String scanId = (String) properties.get(SCAN_ID);
+        String scheduleId = (String) properties.get(SCHEDULE_ID);
+        String emaId = (String) properties.get(EVENT_MANAGEMENT_ID);
+        String importId = (String) exchange.getProperty(IMPORT_ID);
+
+        List<ManualImportFilesEntity> manualImportFilesEntityList = files.stream()
+                .map(file -> ManualImportFilesEntity.builder()
+                        .id(idGenerator.generateRandomUniqueId())
+                        .fileName(file.getFileName())
+                        .dataEntityType(file.getDataEntityType())
+                        .importId(importId)
+                        .scheduleId(scheduleId)
+                        .emaId(emaId)
+                        .scanId(scanId)
+                        .build())
+                .collect(Collectors.toList());
+        manualImportFilesService.saveAll(manualImportFilesEntityList);
+        log.debug("saved manualImportFilesEntityList: {}", manualImportFilesEntityList);
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPublishImportScanEventProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPublishImportScanEventProcessor.java
@@ -51,7 +51,7 @@ public class ScanDataImportPublishImportScanEventProcessor implements Processor 
         Boolean isImportOp = (Boolean) properties.get(RouteConstants.IS_DATA_IMPORT);
 
         ScanDataImportMessage importDataMessage =
-                new ScanDataImportMessage(orgId, scanId, messagingServiceId, scanTypes);
+                new ScanDataImportMessage(orgId, scanId, messagingServiceId, scanTypes, runtimeAgentId);
 
         topicDetails.put("orgId", orgId);
         topicDetails.put("runtimeAgentId", runtimeAgentId);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPublishImportScanEventProcessor.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPublishImportScanEventProcessor.java
@@ -8,7 +8,6 @@ import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDe
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
@@ -26,9 +25,8 @@ public class ScanDataImportPublishImportScanEventProcessor implements Processor 
 
     private final ScanDataPublisher scanDataPublisher;
 
-    @Autowired
-    public ScanDataImportPublishImportScanEventProcessor(ScanDataPublisher scanDataPublisher, EventPortalProperties eventPortalProperties) {
-        super();
+    public ScanDataImportPublishImportScanEventProcessor(ScanDataPublisher scanDataPublisher,
+                                                         EventPortalProperties eventPortalProperties) {
 
         this.scanDataPublisher = scanDataPublisher;
 
@@ -51,11 +49,9 @@ public class ScanDataImportPublishImportScanEventProcessor implements Processor 
         String messagingServiceId = (String) properties.get(RouteConstants.MESSAGING_SERVICE_ID);
         String scanId = (String) properties.get(RouteConstants.SCAN_ID);
         Boolean isImportOp = (Boolean) properties.get(RouteConstants.IS_DATA_IMPORT);
-        String emaId = (String) properties.get(RouteConstants.EVENT_MANAGEMENT_ID);
-        String scheduleId = (String) properties.get(RouteConstants.SCHEDULE_ID);
 
         ScanDataImportMessage importDataMessage =
-                new ScanDataImportMessage(orgId, scanId, messagingServiceId, scanTypes, emaId, scheduleId);
+                new ScanDataImportMessage(orgId, scanId, messagingServiceId, scanTypes);
 
         topicDetails.put("orgId", orgId);
         topicDetails.put("runtimeAgentId", runtimeAgentId);

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/manualimport/ManualImportDetailsRepository.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/manualimport/ManualImportDetailsRepository.java
@@ -1,0 +1,12 @@
+package com.solace.maas.ep.event.management.agent.repository.manualimport;
+
+import com.solace.maas.ep.event.management.agent.repository.model.manualimport.ManualImportDetailsEntity;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ManualImportDetailsRepository extends CrudRepository<ManualImportDetailsEntity, String> {
+    Optional<ManualImportDetailsEntity> getByScanId(String scanId);
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/manualimport/ManualImportFilesRepository.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/manualimport/ManualImportFilesRepository.java
@@ -1,0 +1,12 @@
+package com.solace.maas.ep.event.management.agent.repository.manualimport;
+
+import com.solace.maas.ep.event.management.agent.repository.model.manualimport.ManualImportFilesEntity;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ManualImportFilesRepository extends CrudRepository<ManualImportFilesEntity, String> {
+    List<ManualImportFilesEntity> getAllByScanId(String scanId);
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/manualimport/ManualImportDetailsEntity.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/manualimport/ManualImportDetailsEntity.java
@@ -17,18 +17,21 @@ import java.io.Serializable;
 @NoArgsConstructor
 @Data
 @Builder
-@Table(name = "MANUAL_IMPORT_FILES")
+@Table(name = "MANUAL_IMPORT_DETAILS")
 @Entity
-public class ManualImportFilesEntity implements Serializable {
+public class ManualImportDetailsEntity implements Serializable {
     @Id
     @Column(name = "ID")
     private String id;
 
-    @Column(name = "FILE_NAME")
-    private String fileName;
+    @Column(name = "SCHEDULE_ID")
+    private String scheduleId;
 
-    @Column(name = "DATA_ENTITY_TYPE")
-    private String dataEntityType;
+    @Column(name = "EMA_ID")
+    private String emaId;
+
+    @Column(name = "IMPORT_ID")
+    private String importId;
 
     @Column(name = "SCAN_ID")
     private String scanId;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/manualimport/ManualImportFilesEntity.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/repository/model/manualimport/ManualImportFilesEntity.java
@@ -1,0 +1,44 @@
+package com.solace.maas.ep.event.management.agent.repository.model.manualimport;
+
+import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.io.Serializable;
+
+@ExcludeFromJacocoGeneratedReport
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Table(name = "MANUAL_IMPORT_FILES")
+@Entity
+public class ManualImportFilesEntity implements Serializable {
+    @Id
+    @Column(name = "ID")
+    private String id;
+
+    @Column(name = "FILE_NAME")
+    private String fileName;
+
+    @Column(name = "DATA_ENTITY_TYPE")
+    private String dataEntityType;
+
+    @Column(name = "SCHEDULE_ID")
+    private String scheduleId;
+
+    @Column(name = "EMA_ID")
+    private String emaId;
+
+    @Column(name = "IMPORT_ID")
+    private String importId;
+
+    @Column(name = "SCAN_ID")
+    private String scanId;
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ImportRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ImportRouteBuilder.java
@@ -33,8 +33,6 @@ public class ImportRouteBuilder extends RouteBuilder {
 
         from("direct:continueImportFiles")
                 .routeId("continueImportFiles")
-                // todo: remove this log
-                .log("moodi YYY we are here yay!!!")
                 .to("direct:sendOverAllInProgressImportStatus")
                 .to("direct:parseAndStreamImportFiles");
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ImportRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ImportRouteBuilder.java
@@ -6,6 +6,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.IMPORT_ID;
+
 @Component
 @ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
 public class ImportRouteBuilder extends RouteBuilder {
@@ -19,8 +21,8 @@ public class ImportRouteBuilder extends RouteBuilder {
                 .process(new ScanDataImportExceptionHandler())
                 .continued(true)
                 .end()
-                .setProperty("IMPORT_ID", header("IMPORT_ID"))
-                .setHeader(Exchange.FILE_NAME, simple("${header.IMPORT_ID}.zip"))
+                .setProperty(IMPORT_ID, header(IMPORT_ID))
+                .setHeader(Exchange.FILE_NAME, simple("${header." + IMPORT_ID + "}.zip"))
                 .toD("file://data_collection/import/compressed_data_collection")
                 .to("direct:checkZipSizeAndUnzipFiles");
 

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ImportRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ImportRouteBuilder.java
@@ -25,7 +25,15 @@ public class ImportRouteBuilder extends RouteBuilder {
                 .to("direct:checkZipSizeAndUnzipFiles");
 
         from("direct:continueParsingUnzippedFiles")
-                .to("direct:parseMetaInfoAndSendOverAllImportStatus")
+                .routeId("continueParsingUnzippedFiles")
+                .to("direct:parseMetaInfoAndSendOverAllImportStatus");
+
+
+        from("direct:continueImportFiles")
+                .routeId("continueImportFiles")
+                // todo: remove this log
+                .log("moodi YYY we are here yay!!!")
+                .to("direct:sendOverAllInProgressImportStatus")
                 .to("direct:parseAndStreamImportFiles");
     }
 }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseMetaInfFileRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseMetaInfFileRouteBuilder.java
@@ -12,6 +12,8 @@ import org.apache.camel.processor.aggregate.UseLatestAggregationStrategy;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.IMPORT_ID;
+
 @Component
 @ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
 public class ScanDataImportParseMetaInfFileRouteBuilder extends RouteBuilder {
@@ -41,7 +43,7 @@ public class ScanDataImportParseMetaInfFileRouteBuilder extends RouteBuilder {
                 .continued(true)
                 .end()
                 .pollEnrich()
-                .simple("file://data_collection/import/unzipped_data_collection/${header.IMPORT_ID}" +
+                .simple("file://data_collection/import/unzipped_data_collection/${header." + IMPORT_ID + "}" +
                         "?fileName=META_INF.json&noop=true&idempotent=false")
                 .aggregationStrategy(new UseLatestAggregationStrategy())
                 .convertBodyTo(String.class)

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseMetaInfFileRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseMetaInfFileRouteBuilder.java
@@ -2,6 +2,7 @@ package com.solace.maas.ep.event.management.agent.route.manualImport;
 
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportOverAllStatusProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportParseMetaInfFileProcessor;
+import com.solace.maas.ep.event.management.agent.processor.ScanDataImportPersistFilePathsProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportPersistScanDataProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportPublishImportScanEventProcessor;
 import com.solace.maas.ep.event.management.agent.route.ep.exceptionhandlers.ScanDataImportExceptionHandler;
@@ -22,15 +23,18 @@ public class ScanDataImportParseMetaInfFileRouteBuilder extends RouteBuilder {
     private final ScanDataImportOverAllStatusProcessor scanDataImportOverAllStatusProcessor;
     private final ScanDataImportPublishImportScanEventProcessor scanDataImportPublishImportScanEventProcessor;
     private final ScanDataImportPersistScanDataProcessor scanDataImportPersistScanDataProcessor;
+    private final ScanDataImportPersistFilePathsProcessor scanDataImportPersistFilePathsProcessor;
 
     public ScanDataImportParseMetaInfFileRouteBuilder(ScanDataImportParseMetaInfFileProcessor scanDataImportParseMetaInfFileProcessor,
                                                       ScanDataImportOverAllStatusProcessor scanDataImportOverAllStatusProcessor,
                                                       ScanDataImportPublishImportScanEventProcessor scanDataImportPublishImportScanEventProcessor,
-                                                      ScanDataImportPersistScanDataProcessor scanDataImportPersistScanDataProcessor) {
+                                                      ScanDataImportPersistScanDataProcessor scanDataImportPersistScanDataProcessor,
+                                                      ScanDataImportPersistFilePathsProcessor scanDataImportPersistFilePathsProcessor) {
         this.scanDataImportParseMetaInfFileProcessor = scanDataImportParseMetaInfFileProcessor;
         this.scanDataImportOverAllStatusProcessor = scanDataImportOverAllStatusProcessor;
         this.scanDataImportPublishImportScanEventProcessor = scanDataImportPublishImportScanEventProcessor;
         this.scanDataImportPersistScanDataProcessor = scanDataImportPersistScanDataProcessor;
+        this.scanDataImportPersistFilePathsProcessor = scanDataImportPersistFilePathsProcessor;
     }
 
     @Override
@@ -49,6 +53,7 @@ public class ScanDataImportParseMetaInfFileRouteBuilder extends RouteBuilder {
                 .convertBodyTo(String.class)
                 .unmarshal().json(JsonLibrary.Jackson, MetaInfFileBO.class)
                 .process(scanDataImportParseMetaInfFileProcessor)
+                .process(scanDataImportPersistFilePathsProcessor)
                 .process(scanDataImportPublishImportScanEventProcessor)
                 // todo : remove this log before merging
                 .log("moodi XXX2 We should be here!");

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseMetaInfFileRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseMetaInfFileRouteBuilder.java
@@ -54,9 +54,7 @@ public class ScanDataImportParseMetaInfFileRouteBuilder extends RouteBuilder {
                 .unmarshal().json(JsonLibrary.Jackson, MetaInfFileBO.class)
                 .process(scanDataImportParseMetaInfFileProcessor)
                 .process(scanDataImportPersistFilePathsProcessor)
-                .process(scanDataImportPublishImportScanEventProcessor)
-                // todo : remove this log before merging
-                .log("moodi XXX2 We should be here!");
+                .process(scanDataImportPublishImportScanEventProcessor);
 
         from("direct:sendOverAllInProgressImportStatus")
                 .routeId("sendOverAllInProgressImportStatus")

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseMetaInfFileRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseMetaInfFileRouteBuilder.java
@@ -48,7 +48,8 @@ public class ScanDataImportParseMetaInfFileRouteBuilder extends RouteBuilder {
                 .unmarshal().json(JsonLibrary.Jackson, MetaInfFileBO.class)
                 .process(scanDataImportParseMetaInfFileProcessor)
                 .process(scanDataImportPublishImportScanEventProcessor)
-                .to("direct:sendOverAllInProgressImportStatus");
+                // todo : remove this log before merging
+                .log("moodi XXX2 We should be here!");
 
         from("direct:sendOverAllInProgressImportStatus")
                 .routeId("sendOverAllInProgressImportStatus")

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseZipFileRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportParseZipFileRouteBuilder.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.Iterator;
 
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.IMPORT_ID;
+
 @Component
 @ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
 public class ScanDataImportParseZipFileRouteBuilder extends RouteBuilder {
@@ -25,7 +27,7 @@ public class ScanDataImportParseZipFileRouteBuilder extends RouteBuilder {
                 .simple("file://data_collection/import/compressed_data_collection?fileName=${header." + Exchange.FILE_NAME + "}&noop=true&idempotent=false")
                 .unmarshal(zipFileDataFormat)
                 .split(bodyAs(Iterator.class))
-                .aggregate(exchangeProperty("IMPORT_ID"), new UseLatestAggregationStrategy())
+                .aggregate(exchangeProperty(IMPORT_ID), new UseLatestAggregationStrategy())
                 .completionPredicate(header(Exchange.SPLIT_COMPLETE).isEqualTo(true))
                 .setProperty("FILE_LIST_SIZE", header(Exchange.SPLIT_SIZE))
                 .to("direct:unzipImportFiles");
@@ -35,8 +37,8 @@ public class ScanDataImportParseZipFileRouteBuilder extends RouteBuilder {
                 .simple("file://${header." + Exchange.FILE_PARENT + "}?fileName=${header." + Exchange.FILE_NAME_ONLY + "}&noop=true&idempotent=false")
                 .split(new ZipSplitter())
                 .streaming()
-                .toD("file://data_collection/import/unzipped_data_collection/${header.IMPORT_ID}")
-                .aggregate(exchangeProperty("IMPORT_ID"), new UseLatestAggregationStrategy())
+                .toD("file://data_collection/import/unzipped_data_collection/${header." + IMPORT_ID + "}")
+                .aggregate(exchangeProperty(IMPORT_ID), new UseLatestAggregationStrategy())
                 .completionSize(exchangeProperty("FILE_LIST_SIZE"))
                 .to("direct:continueParsingUnzippedFiles");
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportStreamFilesRouteBuilder.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/route/manualImport/ScanDataImportStreamFilesRouteBuilder.java
@@ -11,6 +11,8 @@ import org.apache.camel.builder.RouteBuilder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.IMPORT_ID;
+
 @Component
 @ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
 public class ScanDataImportStreamFilesRouteBuilder extends RouteBuilder {
@@ -36,7 +38,7 @@ public class ScanDataImportStreamFilesRouteBuilder extends RouteBuilder {
                 .to("direct:perRouteScanStatusPublisher?block=false&failIfNoConsumers=false")
 
                 .pollEnrich()
-                .simple("file://data_collection/import/unzipped_data_collection/${header.IMPORT_ID}?" +
+                .simple("file://data_collection/import/unzipped_data_collection/${header." + IMPORT_ID + "}?" +
                         "fileName=${body.fileName}&noop=true&idempotent=false")
                 .aggregationStrategy(new FileParseAggregationStrategy())
                 .process(scanDataImportPersistScanFilesProcessor)

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ImportService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ImportService.java
@@ -31,6 +31,8 @@ import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.IMPORT_ID;
+
 @Slf4j
 @Service
 public class ImportService {
@@ -67,7 +69,7 @@ public class ImportService {
                 .build();
 
         producerTemplate.asyncSend("seda:" + route.getId(), exchange -> {
-            exchange.getIn().setHeader("IMPORT_ID", importId);
+            exchange.getIn().setHeader(IMPORT_ID, importId);
             exchange.getIn().setBody(files);
         });
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ManualImportDetailsService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ManualImportDetailsService.java
@@ -1,0 +1,24 @@
+package com.solace.maas.ep.event.management.agent.service;
+
+import com.solace.maas.ep.event.management.agent.repository.manualimport.ManualImportDetailsRepository;
+import com.solace.maas.ep.event.management.agent.repository.model.manualimport.ManualImportDetailsEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class ManualImportDetailsService {
+    private final ManualImportDetailsRepository manualImportDetailsRepository;
+
+    public ManualImportDetailsService(ManualImportDetailsRepository manualImportDetailsRepository) {
+        this.manualImportDetailsRepository = manualImportDetailsRepository;
+    }
+
+    public ManualImportDetailsEntity save(ManualImportDetailsEntity manualImportDetailsEntity) {
+        return manualImportDetailsRepository.save(manualImportDetailsEntity);
+    }
+
+    public Optional<ManualImportDetailsEntity> getByScanId(String scanId) {
+        return manualImportDetailsRepository.getByScanId(scanId);
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ManualImportFilesService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ManualImportFilesService.java
@@ -1,0 +1,24 @@
+package com.solace.maas.ep.event.management.agent.service;
+
+import com.solace.maas.ep.event.management.agent.repository.manualimport.ManualImportFilesRepository;
+import com.solace.maas.ep.event.management.agent.repository.model.manualimport.ManualImportFilesEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ManualImportFilesService {
+    private final ManualImportFilesRepository manualImportFilesRepository;
+
+    public ManualImportFilesService(ManualImportFilesRepository manualImportFilesRepository) {
+        this.manualImportFilesRepository = manualImportFilesRepository;
+    }
+
+    public Iterable<ManualImportFilesEntity> saveAll(List<ManualImportFilesEntity> manualImportFilesEntityList) {
+        return manualImportFilesRepository.saveAll(manualImportFilesEntityList);
+    }
+
+    public List<ManualImportFilesEntity> getAllByScanId(String scanId) {
+        return manualImportFilesRepository.getAllByScanId(scanId);
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/ScanCommandMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/ScanCommandMessageHandler.java
@@ -27,7 +27,7 @@ public class ScanCommandMessageHandler extends SolaceMessageHandler<ScanCommandM
     public ScanCommandMessageHandler(
             SolaceConfiguration solaceConfiguration,
             SolaceSubscriber solaceSubscriber, ScanManager scanManager, ScanRequestMapper scanRequestMapper) {
-        super(solaceConfiguration.getTopicPrefix() + "scan/command/>", solaceSubscriber);
+        super(solaceConfiguration.getTopicPrefix() + "scan/command/v1/startScan/>", solaceSubscriber);
         this.scanManager = scanManager;
         this.scanRequestMapper = scanRequestMapper;
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/ScanCommandMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/ScanCommandMessageHandler.java
@@ -27,7 +27,7 @@ public class ScanCommandMessageHandler extends SolaceMessageHandler<ScanCommandM
     public ScanCommandMessageHandler(
             SolaceConfiguration solaceConfiguration,
             SolaceSubscriber solaceSubscriber, ScanManager scanManager, ScanRequestMapper scanRequestMapper) {
-        super(solaceConfiguration.getTopicPrefix() + "scan/command/v1/startScan/>", solaceSubscriber);
+        super(solaceConfiguration.getTopicPrefix() + "scan/command/v1/scanStart/>", solaceSubscriber);
         this.scanManager = scanManager;
         this.scanRequestMapper = scanRequestMapper;
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/StartImportScanCommandMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/StartImportScanCommandMessageHandler.java
@@ -1,0 +1,52 @@
+package com.solace.maas.ep.event.management.agent.subscriber;
+
+import com.solace.maas.ep.common.messages.ScanDataImportMessage;
+import com.solace.maas.ep.event.management.agent.config.SolaceConfiguration;
+import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.ProducerTemplate;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.EVENT_MANAGEMENT_ID;
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.MESSAGING_SERVICE_ID;
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.SCAN_TYPE;
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.SCHEDULE_ID;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
+public class StartImportScanCommandMessageHandler extends SolaceMessageHandler<ScanDataImportMessage> {
+
+    private final ProducerTemplate producerTemplate;
+
+    public StartImportScanCommandMessageHandler(
+            SolaceConfiguration solaceConfiguration,
+            SolaceSubscriber solaceSubscriber,
+            ProducerTemplate producerTemplate) {
+        super(solaceConfiguration.getTopicPrefix() + "scan/command/v1/startImportScan/>", solaceSubscriber);
+        this.producerTemplate = producerTemplate;
+    }
+
+    @Override
+    public void receiveMessage(String destinationName, ScanDataImportMessage message) {
+        List<String> destinations = new ArrayList<>();
+
+        log.debug("Received startImportScan command message: {} for messaging service: {}",
+                message, message.getMessagingServiceId());
+
+        String scanTypes = StringUtils.join(message.getScanTypes(), ",");
+
+        producerTemplate.send("direct:continueImportFiles", exchange -> {
+            exchange.getIn().setHeader(RouteConstants.SCAN_ID, message.getScanId());
+            exchange.getIn().setHeader(SCHEDULE_ID, message.getScheduleId());
+            exchange.getIn().setHeader(EVENT_MANAGEMENT_ID, message.getEmaId());
+            exchange.getIn().setHeader(MESSAGING_SERVICE_ID, message.getMessagingServiceId());
+            exchange.getIn().setHeader(SCAN_TYPE, scanTypes);
+        });
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/StartImportScanCommandMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/StartImportScanCommandMessageHandler.java
@@ -2,18 +2,21 @@ package com.solace.maas.ep.event.management.agent.subscriber;
 
 import com.solace.maas.ep.common.messages.ScanDataImportMessage;
 import com.solace.maas.ep.event.management.agent.config.SolaceConfiguration;
-import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.repository.model.manualimport.ManualImportFilesEntity;
+import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDetailsBO;
+import com.solace.maas.ep.event.management.agent.service.ManualImportFilesService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.ProducerTemplate;
-import org.apache.commons.lang.StringUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.EVENT_MANAGEMENT_ID;
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.IMPORT_ID;
 import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.MESSAGING_SERVICE_ID;
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.SCAN_ID;
 import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.SCAN_TYPE;
 import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.SCHEDULE_ID;
 
@@ -23,30 +26,49 @@ import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteCo
 public class StartImportScanCommandMessageHandler extends SolaceMessageHandler<ScanDataImportMessage> {
 
     private final ProducerTemplate producerTemplate;
+    private final ManualImportFilesService manualImportFilesService;
 
     public StartImportScanCommandMessageHandler(
             SolaceConfiguration solaceConfiguration,
             SolaceSubscriber solaceSubscriber,
-            ProducerTemplate producerTemplate) {
+            ProducerTemplate producerTemplate,
+            ManualImportFilesService manualImportFilesService) {
         super(solaceConfiguration.getTopicPrefix() + "scan/command/v1/startImportScan/>", solaceSubscriber);
         this.producerTemplate = producerTemplate;
+        this.manualImportFilesService = manualImportFilesService;
     }
 
     @Override
     public void receiveMessage(String destinationName, ScanDataImportMessage message) {
-        List<String> destinations = new ArrayList<>();
-
         log.debug("Received startImportScan command message: {} for messaging service: {}",
                 message, message.getMessagingServiceId());
 
-        String scanTypes = StringUtils.join(message.getScanTypes(), ",");
+        String scanId = message.getScanId();
+
+        String scanTypes = String.join(",", message.getScanTypes());
+        List<ManualImportFilesEntity> manualImportFilesEntityList = manualImportFilesService.getAllByScanId(scanId);
+
+        if (manualImportFilesEntityList.isEmpty()) {
+            throw new RuntimeException(String.format("can't retrieve any manualImportFiles for scanId: {}", scanId));
+        }
+
+        ManualImportFilesEntity firstManualImportFilesEntity = manualImportFilesEntityList.get(0);
+
+        List<MetaInfFileDetailsBO> metaInfFileDetailsBOList = manualImportFilesEntityList.stream()
+                .map(manualImportFilesEntity -> MetaInfFileDetailsBO.builder()
+                        .fileName(manualImportFilesEntity.getFileName())
+                        .dataEntityType(manualImportFilesEntity.getDataEntityType())
+                        .build())
+                .collect(Collectors.toList());
 
         producerTemplate.send("direct:continueImportFiles", exchange -> {
-            exchange.getIn().setHeader(RouteConstants.SCAN_ID, message.getScanId());
-            exchange.getIn().setHeader(SCHEDULE_ID, message.getScheduleId());
-            exchange.getIn().setHeader(EVENT_MANAGEMENT_ID, message.getEmaId());
+            exchange.getIn().setHeader(SCAN_ID, scanId);
+            exchange.getIn().setHeader(SCHEDULE_ID, firstManualImportFilesEntity.getScheduleId());
+            exchange.getIn().setHeader(EVENT_MANAGEMENT_ID, firstManualImportFilesEntity.getEmaId());
+            exchange.getIn().setHeader(IMPORT_ID, firstManualImportFilesEntity.getImportId());
             exchange.getIn().setHeader(MESSAGING_SERVICE_ID, message.getMessagingServiceId());
             exchange.getIn().setHeader(SCAN_TYPE, scanTypes);
+            exchange.getIn().setBody(metaInfFileDetailsBOList);
         });
     }
 }

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanDataImportParseMetaInfFileRouteBuilderTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanDataImportParseMetaInfFileRouteBuilderTests.java
@@ -3,6 +3,7 @@ package com.solace.maas.ep.event.management.agent.plugin.route.handler;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportOverAllStatusProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportParseMetaInfFileProcessor;
+import com.solace.maas.ep.event.management.agent.processor.ScanDataImportPersistFilePathsProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportPersistScanDataProcessor;
 import com.solace.maas.ep.event.management.agent.processor.ScanDataImportPublishImportScanEventProcessor;
 import com.solace.maas.ep.event.management.agent.route.manualImport.ScanDataImportParseMetaInfFileRouteBuilder;
@@ -108,9 +109,12 @@ public class ScanDataImportParseMetaInfFileRouteBuilderTests {
                     = mock(ScanDataImportPublishImportScanEventProcessor.class);
             ScanDataImportPersistScanDataProcessor scanDataImportPersistScanDataProcessor
                     = mock(ScanDataImportPersistScanDataProcessor.class);
+            ScanDataImportPersistFilePathsProcessor scanDataImportPersistFilePathsProcessor
+                    = mock(ScanDataImportPersistFilePathsProcessor.class);
 
             return new ScanDataImportParseMetaInfFileRouteBuilder(scanDataImportParseMetaInfFileProcessor,
-                    scanDataImportOverAllStatusProcessor, scanDataImportPublishProcessor, scanDataImportPersistScanDataProcessor);
+                    scanDataImportOverAllStatusProcessor, scanDataImportPublishProcessor,
+                    scanDataImportPersistScanDataProcessor, scanDataImportPersistFilePathsProcessor);
         }
 
         public static String getMetaInfJson() throws JSONException {

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanDataImportParseMetaInfFileRouteBuilderTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanDataImportParseMetaInfFileRouteBuilderTests.java
@@ -66,8 +66,6 @@ public class ScanDataImportParseMetaInfFileRouteBuilderTests {
                         exchange1.getIn().setHeader("CamelFileName", "META_INF.json");
                         exchange1.getIn().setBody(getMetaInfJson());
                     });
-                    route.weaveByToUri("direct:sendOverAllInProgressImportStatus")
-                            .replace().to("mock:sendOverAllInProgressImportStatus");
                     route.weaveAddLast().to("mock:direct:mockParseMetaInfoResult");
                 });
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanDataImportStreamFilesRouteBuilderTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/plugin/route/handler/ScanDataImportStreamFilesRouteBuilderTests.java
@@ -28,6 +28,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.List;
 import java.util.UUID;
 
+import static com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants.IMPORT_ID;
 import static org.mockito.Mockito.mock;
 
 @CamelSpringBootTest
@@ -63,7 +64,7 @@ public class ScanDataImportStreamFilesRouteBuilderTests {
 
         Exchange exchange = new DefaultExchange(camelContext);
         exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, "messagingService");
-        exchange.getIn().setHeader("IMPORT_ID", UUID.randomUUID().toString());
+        exchange.getIn().setHeader(IMPORT_ID, UUID.randomUUID().toString());
         exchange.getIn().setHeader(RouteConstants.SCAN_ID, "scan1");
         exchange.getIn().setBody(files);
 
@@ -88,7 +89,7 @@ public class ScanDataImportStreamFilesRouteBuilderTests {
 
         Exchange exchange = new DefaultExchange(camelContext);
         exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, "messagingService");
-        exchange.getIn().setHeader("IMPORT_ID", UUID.randomUUID().toString());
+        exchange.getIn().setHeader(IMPORT_ID, UUID.randomUUID().toString());
         exchange.getIn().setHeader(RouteConstants.SCAN_ID, "scan1");
         exchange.getIn().setHeader(Exchange.SPLIT_COMPLETE, true);
         exchange.getIn().setBody("test data");
@@ -111,7 +112,7 @@ public class ScanDataImportStreamFilesRouteBuilderTests {
 
         Exchange exchange = new DefaultExchange(camelContext);
         exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, "messagingService");
-        exchange.getIn().setHeader("IMPORT_ID", UUID.randomUUID().toString());
+        exchange.getIn().setHeader(IMPORT_ID, UUID.randomUUID().toString());
         exchange.getIn().setHeader(RouteConstants.SCAN_ID, "scan1");
         exchange.getIn().setBody("test data");
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPersistFilePathsProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanDataImportPersistFilePathsProcessorTests.java
@@ -1,0 +1,73 @@
+package com.solace.maas.ep.event.management.agent.processor;
+
+import com.solace.maas.ep.event.management.agent.TestConfig;
+import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDetailsBO;
+import com.solace.maas.ep.event.management.agent.service.ManualImportDetailsService;
+import com.solace.maas.ep.event.management.agent.service.ManualImportFilesService;
+import com.solace.maas.ep.event.management.agent.util.IDGenerator;
+import lombok.SneakyThrows;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.Rule;
+import org.junit.jupiter.api.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("TEST")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
+public class ScanDataImportPersistFilePathsProcessorTests {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Autowired
+    CamelContext camelContext;
+
+    @InjectMocks
+    ScanDataImportPersistFilePathsProcessor scanDataImportPersistFilePathsProcessor;
+
+    @Mock
+    IDGenerator idGenerator;
+
+    @Mock
+    ManualImportDetailsService manualImportDetailsService;
+
+    @Mock
+    ManualImportFilesService manualImportFilesService;
+
+    @SneakyThrows
+    @Test
+    public void testScanDataImportPersistFilePathsProcessor() {
+        List<MetaInfFileDetailsBO> metaInfFileBO = List.of(MetaInfFileDetailsBO.builder()
+                .fileName("topicListing.json")
+                .dataEntityType("topicListing")
+                .build());
+
+        Exchange exchange = new DefaultExchange(camelContext);
+        exchange.getIn().setBody(metaInfFileBO);
+
+        when(idGenerator.generateRandomUniqueId())
+                .thenReturn("abc123");
+        when(manualImportDetailsService.save(any())).thenReturn(null);
+        when(manualImportFilesService.saveAll(any())).thenReturn(null);
+
+        scanDataImportPersistFilePathsProcessor.process(exchange);
+
+        assertThatNoException();
+
+        exchange.setProperty(Exchange.EXCEPTION_CAUGHT, new Exception());
+        scanDataImportPersistFilePathsProcessor.process(exchange);
+
+        exception.expect(Exception.class);
+    }
+}

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanDataPublishImportScanEventProcessorTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/processor/ScanDataPublishImportScanEventProcessorTests.java
@@ -4,6 +4,7 @@ import com.solace.maas.ep.event.management.agent.TestConfig;
 import com.solace.maas.ep.event.management.agent.config.eventPortal.EventPortalProperties;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.publisher.ScanDataPublisher;
+import com.solace.maas.ep.event.management.agent.scanManager.model.MetaInfFileDetailsBO;
 import com.solace.maas.ep.event.management.agent.util.IDGenerator;
 import lombok.SneakyThrows;
 import org.apache.camel.CamelContext;
@@ -17,6 +18,8 @@ import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
@@ -51,6 +54,10 @@ public class ScanDataPublishImportScanEventProcessorTests {
         exchange.getIn().setHeader(RouteConstants.MESSAGING_SERVICE_ID, "messagingServiceId");
         exchange.getIn().setHeader(RouteConstants.SCAN_ID, scanId);
         exchange.getIn().setHeader(RouteConstants.IS_DATA_IMPORT, true);
+        exchange.getIn().setBody(List.of(MetaInfFileDetailsBO.builder()
+                .fileName("foo.json")
+                .dataEntityType("bar")
+                .build()));
 
         scanDataPublishImportScanEventProcessor.process(exchange);
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/subscriber/MessageReceiverTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/subscriber/MessageReceiverTests.java
@@ -3,12 +3,17 @@ package com.solace.maas.ep.event.management.agent.subscriber;
 import com.solace.maas.ep.common.messages.ScanCommandMessage;
 import com.solace.maas.ep.event.management.agent.TestConfig;
 import com.solace.maas.ep.event.management.agent.config.SolaceConfiguration;
+import com.solace.maas.ep.event.management.agent.plugin.mop.MOPConstants;
+import com.solace.maas.ep.event.management.agent.repository.model.manualimport.ManualImportDetailsEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.manualimport.ManualImportFilesEntity;
 import com.solace.maas.ep.event.management.agent.scanManager.ScanManager;
 import com.solace.maas.ep.event.management.agent.scanManager.mapper.ScanRequestMapper;
-import com.solace.maas.ep.event.management.agent.plugin.mop.MOPConstants;
+import com.solace.maas.ep.event.management.agent.service.ManualImportDetailsService;
+import com.solace.maas.ep.event.management.agent.service.ManualImportFilesService;
 import com.solace.messaging.receiver.InboundMessage;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.ProducerTemplate;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,12 +21,15 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static com.solace.maas.ep.common.model.ScanDestination.EVENT_PORTAL;
 import static com.solace.maas.ep.common.model.ScanType.KAFKA_ALL;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ActiveProfiles("TEST")
@@ -44,6 +52,15 @@ public class MessageReceiverTests {
 
     @Autowired
     ScanRequestMapper scanRequestMapper;
+
+    @Mock
+    ProducerTemplate producerTemplate;
+
+    @Mock
+    ManualImportFilesService manualImportFilesService;
+
+    @Mock
+    ManualImportDetailsService manualImportDetailsService;
 
     @Test
     @SneakyThrows
@@ -100,7 +117,53 @@ public class MessageReceiverTests {
                 new ScanCommandMessage("messagingServiceId",
                         "scanId", List.of(KAFKA_ALL), List.of(EVENT_PORTAL));
 
-        scanCommandMessageHandler.receiveMessage("test",scanCommandMessage);
+        scanCommandMessageHandler.receiveMessage("test", scanCommandMessage);
+        assertThatNoException();
+    }
+
+    @Test
+    @SneakyThrows
+    public void startImportScanCommandMessageHandlerTest() {
+        String payload = "{\n" +
+                "  \"mopVer\" : \"1\",\n" +
+                "  \"mopProtocol\" : \"event\",\n" +
+                "  \"mopMsgType\" : \"generic\",\n" +
+                "  \"msgUh\" : \"ignore\",\n" +
+                "  \"repeat\" : false,\n" +
+                "  \"isReplyMessage\" : false,\n" +
+                "  \"msgPriority\" : 4,\n" +
+                "  \"traceId\" : \"80817f0d335b6221\",\n" +
+                "  \"scanId\" : \"someScanId\",\n" +
+                "  \"scanTypes\" : [\"a\",\"b\",\"c\"]\n" +
+                "}";
+
+        when(inboundMessage.getPayloadAsString()).thenReturn(payload);
+        when(inboundMessage.getProperty(MOPConstants.MOP_MSG_META_DECODER)).thenReturn(
+                "com.solace.maas.ep.common.messages.ScanDataImportMessage");
+        when(inboundMessage.getDestinationName()).thenReturn("anyTopic");
+
+        List<ManualImportFilesEntity> mockedManualImportFilesEntity = new ArrayList<>();
+        mockedManualImportFilesEntity.add(
+                ManualImportFilesEntity.builder()
+                        .id("idManualImportFilesEntity")
+                        .fileName("someFileName.json")
+                        .dataEntityType("someDataEntityType")
+                        .scanId("someScan")
+                        .build());
+        when(manualImportFilesService.getAllByScanId(anyString())).thenReturn(mockedManualImportFilesEntity);
+
+        ManualImportDetailsEntity mockedManualImportDetailsEntity = ManualImportDetailsEntity.builder()
+                .id("idManualImportDetailsEntity")
+                .importId("someImportId")
+                .scheduleId("someScheduleId")
+                .emaId("someEmaId")
+                .scanId("someScanId")
+                .build();
+        when(manualImportDetailsService.getByScanId(anyString())).thenReturn(Optional.ofNullable(mockedManualImportDetailsEntity));
+
+        StartImportScanCommandMessageHandler startImportScanCommandMessageHandler = new StartImportScanCommandMessageHandler(solaceConfiguration,
+                solaceSubscriber, producerTemplate, manualImportFilesService, manualImportDetailsService);
+        startImportScanCommandMessageHandler.onMessage(inboundMessage);
         assertThatNoException();
     }
 

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/constants/RouteConstants.java
@@ -28,4 +28,5 @@ public class RouteConstants {
     public static final String SCAN_DATA_STATUS_MESSAGE = "SCAN_DATA_STATUS_MESSAGE";
 
     public static final String TOPIC_DETAILS = "TOPIC_DETAILS";
+    public static final String IMPORT_ID = "IMPORT_ID";
 }


### PR DESCRIPTION
### What is the purpose of this change?
To synchronize the initial messages between EP and EMA so that EMA won't send data to EP until EP has persisted the scanId and scanTypes to its DB

### How was this change implemented?
broke up the `ScanDataImportParseMetaInfFileRouteBuilder` so that it sends the initial `importScan` message to EP, and the resume the rest of the route once EP sends back a `startImportScan` message.

### How was this change tested?
Manual testings, but the EP changes are not ready yet, so more testing will occur before merging this PR.
For now I have mocked the messages being sent by EP to make sure the scan resumes as expected on EMA side.

### Is there anything the reviewers should focus on/be aware of?
Just added an `IMPORT_ID` constant and made the required refactoring for it.
