### PR TITLE
DATAGO-50363: add handshake for regular scans

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataCollectionTypesMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataCollectionTypesMessage.java
@@ -1,6 +1,7 @@
 package com.solace.maas.ep.common.messages;
 
 import com.solace.maas.ep.common.model.ScanType;
+import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
 import com.solace.maas.ep.event.management.agent.plugin.mop.MOPMessage;
 import com.solace.maas.ep.event.management.agent.plugin.mop.MOPMessageType;
 import com.solace.maas.ep.event.management.agent.plugin.mop.MOPProtocol;
@@ -12,6 +13,7 @@ import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
+@ExcludeFromJacocoGeneratedReport
 public class ScanDataCollectionTypesMessage extends MOPMessage {
     String orgId;
     String emaId;

--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataCollectionTypesMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanDataCollectionTypesMessage.java
@@ -1,0 +1,43 @@
+package com.solace.maas.ep.common.messages;
+
+import com.solace.maas.ep.common.model.ScanType;
+import com.solace.maas.ep.event.management.agent.plugin.mop.MOPMessage;
+import com.solace.maas.ep.event.management.agent.plugin.mop.MOPMessageType;
+import com.solace.maas.ep.event.management.agent.plugin.mop.MOPProtocol;
+import com.solace.maas.ep.event.management.agent.plugin.mop.MOPUHFlag;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class ScanDataCollectionTypesMessage extends MOPMessage {
+    String orgId;
+    String emaId;
+    String scanId;
+    String messagingServiceId;
+    private List<ScanType> scanTypes;
+
+    public ScanDataCollectionTypesMessage() {
+        super();
+    }
+
+    public ScanDataCollectionTypesMessage(String orgId,
+                                          String emaId,
+                                          String scanId,
+                                          String messagingServiceId,
+                                          List<ScanType> scanTypes) {
+        super();
+        withMessageType(MOPMessageType.generic)
+                .withProtocol(MOPProtocol.event)
+                .withVersion("1")
+                .withUhFlag(MOPUHFlag.ignore);
+
+        this.orgId = orgId;
+        this.emaId = emaId;
+        this.scanId = scanId;
+        this.messagingServiceId = messagingServiceId;
+        this.scanTypes = scanTypes;
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanTypesMessage.java
+++ b/service/application/src/main/java/com/solace/maas/ep/common/messages/ScanTypesMessage.java
@@ -1,0 +1,39 @@
+package com.solace.maas.ep.common.messages;
+
+import com.solace.maas.ep.event.management.agent.plugin.mop.MOPMessage;
+import com.solace.maas.ep.event.management.agent.plugin.mop.MOPMessageType;
+import com.solace.maas.ep.event.management.agent.plugin.mop.MOPProtocol;
+import com.solace.maas.ep.event.management.agent.plugin.mop.MOPUHFlag;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class ScanTypesMessage extends MOPMessage {
+    String orgId;
+
+    String scanId;
+
+    String messagingServiceId;
+
+    private List<String> scanTypes;
+
+    public ScanTypesMessage() {
+        super();
+    }
+
+    public ScanTypesMessage(String orgId, String scanId, String messagingServiceId, List<String> scanTypes) {
+        super();
+        withMessageType(MOPMessageType.generic)
+                .withProtocol(MOPProtocol.event)
+                .withVersion("1")
+                .withUhFlag(MOPUHFlag.ignore);
+
+        this.orgId = orgId;
+        this.scanId = scanId;
+        this.messagingServiceId = messagingServiceId;
+        this.scanTypes = scanTypes;
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/ScanDataCollectionTypesPublisher.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/ScanDataCollectionTypesPublisher.java
@@ -21,14 +21,15 @@ public class ScanDataCollectionTypesPublisher {
      * Sends the scan related dataCollectionTypes to EP.
      * <p>
      * The topic:
-     * sc/ep/runtime/{orgId}/{emaId}/scan/information/v1/dataCollectionTypes/{messagingServiceId}
+     * sc/ep/runtime/{orgId}/{emaId}/scan/information/v1/dataCollectionTypes/{messagingServiceId}/{scanId}
      */
 
     public void sendScanDataCollectionTypes(MOPMessage message, Map<String, String> topicDetails) {
-        String topicString = String.format("sc/ep/runtime/%s/%s/scan/information/v1/dataCollectionTypes/%s",
+        String topicString = String.format("sc/ep/runtime/%s/%s/scan/information/v1/dataCollectionTypes/%s/%s",
                 topicDetails.get("orgId"),
                 topicDetails.get("emaId"),
-                topicDetails.get("messagingServiceId"));
+                topicDetails.get("messagingServiceId"),
+                topicDetails.get("scanId"));
 
         solacePublisher.publish(message, topicString);
     }

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/ScanDataCollectionTypesPublisher.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/ScanDataCollectionTypesPublisher.java
@@ -1,0 +1,35 @@
+package com.solace.maas.ep.event.management.agent.publisher;
+
+import com.solace.maas.ep.event.management.agent.plugin.mop.MOPMessage;
+import com.solace.maas.ep.event.management.agent.plugin.publisher.SolacePublisher;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+public class ScanDataCollectionTypesPublisher {
+
+    private final SolacePublisher solacePublisher;
+
+    public ScanDataCollectionTypesPublisher(SolacePublisher solacePublisher) {
+        this.solacePublisher = solacePublisher;
+    }
+
+    /**
+     * Sends the scan related dataCollectionTypes to EP.
+     * <p>
+     * The topic:
+     * sc/ep/runtime/{orgId}/{emaId}/scan/information/v1/dataCollectionTypes/{messagingServiceId}
+     */
+
+    public void sendScanDataCollectionTypes(MOPMessage message, Map<String, String> topicDetails) {
+        String topicString = String.format("sc/ep/runtime/%s/%s/scan/information/v1/dataCollectionTypes/%s",
+                topicDetails.get("orgId"),
+                topicDetails.get("emaId"),
+                topicDetails.get("messagingServiceId"));
+
+        solacePublisher.publish(message, topicString);
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/ScanDataCollectionTypesPublisher.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/publisher/ScanDataCollectionTypesPublisher.java
@@ -1,5 +1,6 @@
 package com.solace.maas.ep.event.management.agent.publisher;
 
+import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
 import com.solace.maas.ep.event.management.agent.plugin.mop.MOPMessage;
 import com.solace.maas.ep.event.management.agent.plugin.publisher.SolacePublisher;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -9,6 +10,7 @@ import java.util.Map;
 
 @Component
 @ConditionalOnExpression("${eventPortal.gateway.messaging.standalone} == false")
+@ExcludeFromJacocoGeneratedReport
 public class ScanDataCollectionTypesPublisher {
 
     private final SolacePublisher solacePublisher;

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/GetScanDataCollectionTypesMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/GetScanDataCollectionTypesMessageHandler.java
@@ -1,0 +1,74 @@
+package com.solace.maas.ep.event.management.agent.subscriber;
+
+import com.solace.maas.ep.common.messages.ScanDataCollectionTypesMessage;
+import com.solace.maas.ep.common.messages.ScanTypesMessage;
+import com.solace.maas.ep.event.management.agent.config.SolaceConfiguration;
+import com.solace.maas.ep.event.management.agent.plugin.route.RouteBundle;
+import com.solace.maas.ep.event.management.agent.plugin.route.handler.base.MessagingServiceRouteDelegate;
+import com.solace.maas.ep.event.management.agent.publisher.ScanDataCollectionTypesPublisher;
+import com.solace.maas.ep.event.management.agent.scanManager.ScanManager;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "event-portal.gateway.messaging.standalone", havingValue = "false")
+public class GetScanDataCollectionTypesMessageHandler extends SolaceMessageHandler<ScanDataCollectionTypesMessage> {
+
+    private final ScanManager scanManager;
+    private final ScanDataCollectionTypesPublisher scanDataCollectionTypesPublisher;
+
+    public GetScanDataCollectionTypesMessageHandler(
+            SolaceConfiguration solaceConfiguration,
+            SolaceSubscriber solaceSubscriber,
+            ScanManager scanManager,
+            ScanDataCollectionTypesPublisher scanDataCollectionTypesPublisher) {
+        super(solaceConfiguration.getTopicPrefix() + "scan/command/v1/getScanDataCollectionTypes/>", solaceSubscriber);
+        this.scanManager = scanManager;
+        this.scanDataCollectionTypesPublisher = scanDataCollectionTypesPublisher;
+    }
+
+    @Override
+    public void receiveMessage(String destinationName, ScanDataCollectionTypesMessage message) {
+
+        List<String> entityTypes = new ArrayList<>();
+        List<RouteBundle> routeBundles;
+        List<String> extractedScanTypes = new ArrayList<>();
+        Map<String, String> topicDetails = new HashMap<>();
+        String orgId = message.getOrgId();
+        String messagingServiceId = message.getMessagingServiceId();
+
+        log.debug("Received getScanDataCollectionTypes command message: {} for messaging service: {}",
+                message, messagingServiceId);
+
+        message.getScanTypes().forEach(scanType -> entityTypes.add(scanType.name()));
+
+        MessagingServiceRouteDelegate scanDelegate = scanManager.getScanDelegate(messagingServiceId);
+        routeBundles = scanManager.getRouteBundles(entityTypes, List.of(), messagingServiceId, scanDelegate);
+
+        extractScanTypes(routeBundles, extractedScanTypes);
+
+        topicDetails.put("orgId", orgId);
+        topicDetails.put("emaId", message.getEmaId());
+        topicDetails.put("messagingServiceId", messagingServiceId);
+
+        ScanTypesMessage scanTypesMessage = new ScanTypesMessage(orgId, message.getScanId(), messagingServiceId, extractedScanTypes);
+
+        log.debug("Will publish scanTypesMessage: {}", scanTypesMessage);
+
+        scanDataCollectionTypesPublisher.sendScanDataCollectionTypes(scanTypesMessage, topicDetails);
+    }
+
+    private void extractScanTypes(List<RouteBundle> routeBundles, List<String> extractedRouteBundles) {
+        for (RouteBundle r : routeBundles) {
+            extractedRouteBundles.add(r.getScanType());
+            extractScanTypes(r.getRecipients(), extractedRouteBundles);
+        }
+    }
+}

--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/GetScanDataCollectionTypesMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/GetScanDataCollectionTypesMessageHandler.java
@@ -43,6 +43,7 @@ public class GetScanDataCollectionTypesMessageHandler extends SolaceMessageHandl
         Map<String, String> topicDetails = new HashMap<>();
         String orgId = message.getOrgId();
         String messagingServiceId = message.getMessagingServiceId();
+        String scanId = message.getScanId();
 
         log.debug("Received getScanDataCollectionTypes command message: {} for messaging service: {}",
                 message, messagingServiceId);
@@ -57,8 +58,9 @@ public class GetScanDataCollectionTypesMessageHandler extends SolaceMessageHandl
         topicDetails.put("orgId", orgId);
         topicDetails.put("emaId", message.getEmaId());
         topicDetails.put("messagingServiceId", messagingServiceId);
+        topicDetails.put("scanId", scanId);
 
-        ScanTypesMessage scanTypesMessage = new ScanTypesMessage(orgId, message.getScanId(), messagingServiceId, extractedScanTypes);
+        ScanTypesMessage scanTypesMessage = new ScanTypesMessage(orgId, scanId, messagingServiceId, extractedScanTypes);
 
         log.debug("Will publish scanTypesMessage: {}", scanTypesMessage);
 

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/subscriber/MessageReceiverTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/subscriber/MessageReceiverTests.java
@@ -210,10 +210,11 @@ public class MessageReceiverTests {
                 "  \"isReplyMessage\" : false,\n" +
                 "  \"msgPriority\" : 4,\n" +
                 "  \"traceId\" : \"80817f0d335b6221\",\n" +
-                "  \"emaId\" : \"someId\",\n" +
+                "  \"emaId\" : \"testEmaId\",\n" +
+                "  \"orgId\" : \"testOrgId\",\n" +
                 "  \"scanTypes\" : [\"KAFKA_ALL\"],\n" +
-                "  \"scanId\" : \"fooBar\",\n" +
-                "  \"messagingServiceId\" : \"someId\"\n" +
+                "  \"scanId\" : \"testScanId\",\n" +
+                "  \"messagingServiceId\" : \"testMessagingServiceId\"\n" +
                 "}";
 
         when(inboundMessage.getPayloadAsString()).thenReturn(payload);


### PR DESCRIPTION
### What is the purpose of this change?
To make sure EP persists all scanTypes before sending any scanData to it.

### How was this change implemented?
Added a new MopMessage receiver and sender so that EP can ask for scanTypes associated to a scan with a given list of `["KAFKA_ALL"]` and in return gets back a list of scanTypes `["clusterConfiguration","brokerConfiguration",...]`.

### How was this change tested?
Manually. The changes on EP side are not ready yet, so more testing will occur before merging this PR

### Is there anything the reviewers should focus on/be aware of?
Nope.
