### PR TITLE
Fix mixed scanIds in the logs of consecutive scans

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/ScanCommandMessageHandler.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/subscriber/ScanCommandMessageHandler.java
@@ -7,6 +7,7 @@ import com.solace.maas.ep.event.management.agent.scanManager.mapper.ScanRequestM
 import com.solace.maas.ep.event.management.agent.scanManager.model.ScanRequestBO;
 import lombok.extern.slf4j.Slf4j;
 import net.logstash.logback.encoder.org.apache.commons.lang3.StringUtils;
+import org.slf4j.MDC;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -34,6 +35,8 @@ public class ScanCommandMessageHandler extends SolaceMessageHandler<ScanCommandM
 
     @Override
     public void receiveMessage(String destinationName, ScanCommandMessage message) {
+        MDC.clear();
+
         List<String> destinations = new ArrayList<>();
         List<String> entityTypes = new ArrayList<>();
 


### PR DESCRIPTION
### What is the purpose of this change?

To fix the issue of mixed scanIds in the logs of consecutive scans

Issue:

<img width="1525" alt="mixed scanIds" src="https://user-images.githubusercontent.com/33485177/230136050-7b7e1454-4cbc-44bd-9341-c6a4f45cb7bc.png">


### How was this change implemented?

By clearing the MDC context upon receiving new scan commands.

### How was this change tested?

Manual

**Fix:**
<img width="1534" alt="fixed issue" src="https://user-images.githubusercontent.com/33485177/230136177-84193e61-fc08-4996-bbde-c862169634ff.png">

### Is there anything the reviewers should focus on/be aware of?

N/A
