### PR TITLE
DATAGO-50714: change webflux to apache http, add support for schemaType and references

### DIFF
--- a/service/confluentSchemaRegistry-plugin/pom.xml
+++ b/service/confluentSchemaRegistry-plugin/pom.xml
@@ -32,6 +32,12 @@
             <version>2.7.6</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/service/confluentSchemaRegistry-plugin/pom.xml
+++ b/service/confluentSchemaRegistry-plugin/pom.xml
@@ -38,6 +38,12 @@
             <version>4.5.13</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.9.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/exception/ClientException.java
+++ b/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/exception/ClientException.java
@@ -1,0 +1,11 @@
+package com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.exception;
+
+public class ClientException extends RuntimeException {
+    public ClientException() {
+        super();
+    }
+
+    public ClientException(String message) {
+        super(message);
+    }
+}

--- a/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/exception/URIException.java
+++ b/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/exception/URIException.java
@@ -1,0 +1,11 @@
+package com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.exception;
+
+public class URIException extends RuntimeException {
+    public URIException() {
+        super();
+    }
+
+    public URIException(String message, Exception e) {
+        super(message, e);
+    }
+}

--- a/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/manager/client/ConfluentSchemaRegistryClientManagerImpl.java
+++ b/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/manager/client/ConfluentSchemaRegistryClientManagerImpl.java
@@ -7,7 +7,7 @@ import com.solace.maas.ep.event.management.agent.plugin.manager.client.Messaging
 import com.solace.maas.ep.event.management.agent.plugin.messagingService.event.ConnectionDetailsEvent;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 @Slf4j
 @ExcludeFromJacocoGeneratedReport
@@ -17,7 +17,7 @@ public class ConfluentSchemaRegistryClientManagerImpl implements MessagingServic
     public ConfluentSchemaRegistryHttp getClient(ConnectionDetailsEvent connectionDetailsEvent) {
         log.debug("creating Confluent Schema Registry client for: {}", connectionDetailsEvent.getMessagingServiceId());
         HttpClient httpClient = HttpClient.builder()
-                .webClient(WebClient.builder().build())
+                .webClient(HttpClientBuilder.create().build())
                 .connectionUrl(connectionDetailsEvent.getUrl())
                 .build();
         log.debug("Confluent Schema Registry client created for {}.", connectionDetailsEvent.getMessagingServiceId());

--- a/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/processor/event/ConfluentSchemaRegistrySchemaEvent.java
+++ b/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/processor/event/ConfluentSchemaRegistrySchemaEvent.java
@@ -16,6 +16,7 @@ public class ConfluentSchemaRegistrySchemaEvent implements Serializable {
     private String version;
     private String id;
     private String references;
+    private String schemaType;
     private String schema;
     private Boolean internal;
 }

--- a/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/processor/event/ConfluentSchemaRegistrySchemaReference.java
+++ b/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/processor/event/ConfluentSchemaRegistrySchemaReference.java
@@ -6,18 +6,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
-import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
 @Builder
-public class ConfluentSchemaRegistrySchemaEvent implements Serializable {
+public class ConfluentSchemaRegistrySchemaReference implements Serializable {
+    private String name;
     private String subject;
     private String version;
-    private String id;
-    private List<ConfluentSchemaRegistrySchemaReference> references;
-    private String schemaType;
-    private String schema;
-    private Boolean internal;
 }

--- a/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/processor/schema/ConfluentSchemaRegistryHttp.java
+++ b/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/processor/schema/ConfluentSchemaRegistryHttp.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.exception.ClientException;
+import com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.exception.URIException;
 import com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.processor.event.ConfluentSchemaRegistrySchemaEvent;
 import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
 import lombok.Getter;
@@ -12,13 +14,12 @@ import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
+import org.springframework.http.HttpStatus;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @ExcludeFromJacocoGeneratedReport
 @SuppressWarnings("CPD-START")
@@ -36,10 +37,14 @@ public class ConfluentSchemaRegistryHttp {
     }
 
     public List<ConfluentSchemaRegistrySchemaEvent> getSchemas() throws JsonProcessingException {
-        Map<String, String> substitutionMap = new HashMap<>();
-        String response = getResponse(getUri(GET_ALL_SCHEMAS));
-        return objectMapper.readValue(response, new TypeReference<>() {
-        });
+        String response;
+        try {
+            response = getResponse(getUri(GET_ALL_SCHEMAS));
+            return objectMapper.readValue(response, new TypeReference<>() {
+            });
+        } catch (ClientException e) {
+            throw (e);
+        }
     }
 
     private URI getUri(String path) {
@@ -48,7 +53,7 @@ public class ConfluentSchemaRegistryHttp {
             uri = new URI(httpClient.getConnectionUrl() + path);
         } catch (URISyntaxException e) {
             log.error("URI error for {}", httpClient.getConnectionUrl(), e);
-            throw new RuntimeException(String.format("Could not construct URL from %s", httpClient.getConnectionUrl()), e);
+            throw new URIException(String.format("Could not construct URL from %s", httpClient.getConnectionUrl()), e);
         }
         return uri;
     }
@@ -57,12 +62,16 @@ public class ConfluentSchemaRegistryHttp {
         HttpGet getData = new HttpGet();
         getData.setURI(uri);
         try (CloseableHttpResponse response = httpClient.getWebClient().execute(getData)) {
-            if (response.getStatusLine().getStatusCode() != 200) {
-
+            if (response.getStatusLine().getStatusCode() != HttpStatus.OK.value()) {
+                log.error("Error response from the Confluent Schema registry {} returned with code {} and message '{}'",
+                        httpClient.getConnectionUrl() + uri.getPath(),
+                        response.getStatusLine().getStatusCode(),
+                        response.getStatusLine().getReasonPhrase());
+                throw new ClientException(String.format("Could not fulfill API call for path %s",
+                        httpClient.getConnectionUrl() + uri.getPath()));
             }
             HttpEntity entity = response.getEntity();
-            String res = EntityUtils.toString(entity);
-            return res;
+            return EntityUtils.toString(entity);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/processor/schema/HttpClient.java
+++ b/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/processor/schema/HttpClient.java
@@ -2,11 +2,11 @@ package com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry
 
 import lombok.Builder;
 import lombok.Data;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.apache.http.impl.client.CloseableHttpClient;
 
 @Data
 @Builder
 public class HttpClient {
-    private WebClient webClient;
+    private CloseableHttpClient webClient;
     private String connectionUrl;
 }

--- a/service/confluentSchemaRegistry-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/manager/processor/ConfluentSchemaRegistryClientTests.java
+++ b/service/confluentSchemaRegistry-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/manager/processor/ConfluentSchemaRegistryClientTests.java
@@ -84,6 +84,8 @@ class ConfluentSchemaRegistryClientTests {
         // schemaType for non-avro is not null
         assertNotNull(confluentSchemaRegistrySchemaEventList.get(2).getSchemaType());
         assertNotNull(confluentSchemaRegistrySchemaEventList.get(3).getSchemaType());
+
+        assertThat(confluentSchemaRegistrySchemaEventList.get(1).getReferences()).hasSize(1);
     }
 
     @SneakyThrows

--- a/service/confluentSchemaRegistry-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/manager/processor/ConfluentSchemaRegistryClientTests.java
+++ b/service/confluentSchemaRegistry-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/manager/processor/ConfluentSchemaRegistryClientTests.java
@@ -1,123 +1,92 @@
 package com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.manager.processor;
 
+import com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.exception.ClientException;
 import com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.processor.event.ConfluentSchemaRegistrySchemaEvent;
 import com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.processor.schema.ConfluentSchemaRegistryHttp;
 import com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.processor.schema.HttpClient;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeEach;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.stubbing.Answer;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.util.DefaultUriBuilderFactory;
-import org.springframework.web.util.UriBuilder;
-import reactor.core.publisher.Mono;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ActiveProfiles("TEST")
 @SpringBootTest(classes = main.java.com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.ConfluentSchemaRegistryApplication.class)
 @Slf4j
 class ConfluentSchemaRegistryClientTests {
-    private final Map<String, String> requestResponseMap = buildRequestResponseMap();
-    private final DefaultUriBuilderFactory defaultUriBuilderFactory = new DefaultUriBuilderFactory();
-    @Captor
-    private ArgumentCaptor<Function<UriBuilder, URI>> uriFunctionCaptor;
-    @Mock
-    private WebClient mockClient;
 
-    private ConfluentSchemaRegistryHttp confluentSchemaRegistryHttp;
+    static private MockWebServer mockWebServer;
 
-    @BeforeEach
-    void setupMocks() {
+    static private ConfluentSchemaRegistryHttp confluentSchemaRegistryHttp;
+
+    private static String VALID_RESPONSE;
+
+    static {
+        try {
+            VALID_RESPONSE = new String(requireNonNull(ConfluentSchemaRegistryClientTests.class
+                    .getClassLoader()
+                    .getResourceAsStream("schemas.json"))
+                    .readAllBytes());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @SneakyThrows
+    @BeforeAll
+    static void setupMocks() {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start(12345);
+
+        CloseableHttpClient mockClient = HttpClients.createDefault();
+
         HttpClient baseClient = HttpClient.builder()
-                .connectionUrl("http://myHost:12345")
+                .connectionUrl("http://localhost:12345")
                 .webClient(mockClient)
                 .build();
 
-        mockHttp(mockClient);
-
         confluentSchemaRegistryHttp = new ConfluentSchemaRegistryHttp(baseClient);
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        mockWebServer.shutdown();
     }
 
     @SneakyThrows
     @Test
     void getAllSchemasTest() {
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(VALID_RESPONSE)
+                .setResponseCode(200));
+
         List<ConfluentSchemaRegistrySchemaEvent> confluentSchemaRegistrySchemaEventList = confluentSchemaRegistryHttp.getSchemas();
         assertThat(confluentSchemaRegistrySchemaEventList).hasSize(3);
         assertThatNoException();
     }
 
-    private void mockHttp(WebClient webClient) {
-        WebClient.RequestHeadersUriSpec request = mock(WebClient.RequestHeadersUriSpec.class);
-        when(webClient.get()).thenReturn(request);
+    @SneakyThrows
+    @Test
+    void getAllSchemasFailTest() {
 
-        when(request.uri(uriFunctionCaptor.capture())).thenAnswer(
-                (Answer) invocation -> {
-                    URI newUri = uriFunctionCaptor.getValue().apply(defaultUriBuilderFactory.builder());
-                    return createWebClientResponse(requestResponseMap.get(newUri.toString()));
-                }
-        );
-    }
-
-    private WebClient.RequestHeadersSpec createWebClientResponse(String response) {
-        WebClient.RequestHeadersSpec requestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
-        when(requestHeadersSpec.header(anyString(), anyString())).thenReturn(requestHeadersSpec);
-        when(requestHeadersSpec.accept(any(MediaType.class))).thenReturn(requestHeadersSpec);
-
-        WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
-        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
-        Mono monoSubjectList = mock(Mono.class);
-
-        when(responseSpec.bodyToMono(any(Class.class))).thenReturn(monoSubjectList);
-        when(monoSubjectList.block()).thenReturn(response);
-
-        return requestHeadersSpec;
-    }
-
-    private Map<String, String> buildRequestResponseMap() {
-        Map<String, String> requestResponseResult = new HashMap<>();
-
-        // Add response for get all schemas
-        requestResponseResult.put("http://myHost:12345/schemas", loadResourceFileAsString("schemas.json"));
-        return requestResponseResult;
-    }
-
-    protected String loadResourceFileAsString(String filePath) {
-        Path resourceDirectory = Paths.get("src", "test", "resources", filePath);
-        Path path = resourceDirectory.toFile().toPath();
-        try {
-            return Files.readString(path);
-        } catch (FileNotFoundException e) {
-            log.error("Could not find resource file " + filePath, e);
-            fail(String.format("Could not find resource file %s", filePath));
-        } catch (IOException e) {
-            log.error("Error reading resource file " + filePath, e);
-            fail(String.format("Error reading resource file %s", filePath));
-        }
-        return null;
+        mockWebServer.enqueue(new MockResponse()
+                .setBody("service unavailable")
+                .setResponseCode(503));
+        assertThrows(ClientException.class, () -> confluentSchemaRegistryHttp.getSchemas());
     }
 }

--- a/service/confluentSchemaRegistry-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/manager/processor/ConfluentSchemaRegistryClientTests.java
+++ b/service/confluentSchemaRegistry-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/manager/processor/ConfluentSchemaRegistryClientTests.java
@@ -77,12 +77,13 @@ class ConfluentSchemaRegistryClientTests {
                 .setResponseCode(200));
 
         List<ConfluentSchemaRegistrySchemaEvent> confluentSchemaRegistrySchemaEventList = confluentSchemaRegistryHttp.getSchemas();
-        assertThat(confluentSchemaRegistrySchemaEventList).hasSize(3);
+        assertThat(confluentSchemaRegistrySchemaEventList).hasSize(4);
         // schemaType for avro is null
         assertNull(confluentSchemaRegistrySchemaEventList.get(0).getSchemaType());
+        assertNull(confluentSchemaRegistrySchemaEventList.get(1).getSchemaType());
         // schemaType for non-avro is not null
-        assertNotNull(confluentSchemaRegistrySchemaEventList.get(1).getSchemaType());
         assertNotNull(confluentSchemaRegistrySchemaEventList.get(2).getSchemaType());
+        assertNotNull(confluentSchemaRegistrySchemaEventList.get(3).getSchemaType());
     }
 
     @SneakyThrows

--- a/service/confluentSchemaRegistry-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/manager/processor/ConfluentSchemaRegistryClientTests.java
+++ b/service/confluentSchemaRegistry-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/manager/processor/ConfluentSchemaRegistryClientTests.java
@@ -21,7 +21,8 @@ import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ActiveProfiles("TEST")
@@ -77,7 +78,11 @@ class ConfluentSchemaRegistryClientTests {
 
         List<ConfluentSchemaRegistrySchemaEvent> confluentSchemaRegistrySchemaEventList = confluentSchemaRegistryHttp.getSchemas();
         assertThat(confluentSchemaRegistrySchemaEventList).hasSize(3);
-        assertThatNoException();
+        // schemaType for avro is null
+        assertNull(confluentSchemaRegistrySchemaEventList.get(0).getSchemaType());
+        // schemaType for non-avro is not null
+        assertNotNull(confluentSchemaRegistrySchemaEventList.get(1).getSchemaType());
+        assertNotNull(confluentSchemaRegistrySchemaEventList.get(2).getSchemaType());
     }
 
     @SneakyThrows

--- a/service/confluentSchemaRegistry-plugin/src/test/resources/schemas.json
+++ b/service/confluentSchemaRegistry-plugin/src/test/resources/schemas.json
@@ -6,15 +6,17 @@
     "schema": "{\"type\":\"record\",\"name\":\"myrecord\",\"fields\":[{\"name\":\"tags\",\"type\":{\"type\":\"map\",\"values\":\"string\"}},{\"name\":\"AVG_NOISE_FLOOR_DBM\",\"type\":[\"null\",\"double\"],\"default\":null},{\"name\":\"OFDM_ANI_LEVEL_ADJUSTED\",\"type\":[\"null\",\"int\"],\"default\":null}]}"
   },
   {
-    "subject": "test-avro",
+    "subject": "test-protobuf",
     "version": 2,
     "id": 2,
-    "schema": "{\"type\":\"record\",\"name\":\"myrecord\",\"fields\":[{\"name\":\"tags\",\"type\":{\"type\":\"map\",\"values\":\"string\"}},{\"name\":\"AVG_NOISE_FLOOR_DBM\",\"type\":[\"null\",\"double\"],\"default\":null},{\"name\":\"OFDM_ANI_LEVEL_ADJUSTED\",\"type\":[\"null\",\"int\"],\"default\":1}]}"
+    "schema": "syntax = \"proto3\";\npackage com.mycorp.mynamespace;\n",
+    "schemaType": "PROTOBUF"
   },
   {
-    "subject": "test-avro",
+    "subject": "test-json",
     "version": 3,
     "id": 3,
-    "schema": "{\"type\":\"record\",\"name\":\"myrecord\",\"fields\":[{\"name\":\"tags\",\"type\":{\"type\":\"map\",\"values\":\"string\"}},{\"name\":\"AVG_NOISE_FLOOR_DBM\",\"type\":[\"null\",\"double\"],\"default\":2.6123},{\"name\":\"OFDM_ANI_LEVEL_ADJUSTED\",\"type\":[\"null\",\"int\"],\"default\":1}]}"
+    "schema": "{\"name\":\"my-foo\",\"realName\":\"my-foobar\"}",
+    "schemaType": "JSON"
   }
 ]

--- a/service/confluentSchemaRegistry-plugin/src/test/resources/schemas.json
+++ b/service/confluentSchemaRegistry-plugin/src/test/resources/schemas.json
@@ -6,16 +6,29 @@
     "schema": "{\"type\":\"record\",\"name\":\"myrecord\",\"fields\":[{\"name\":\"tags\",\"type\":{\"type\":\"map\",\"values\":\"string\"}},{\"name\":\"AVG_NOISE_FLOOR_DBM\",\"type\":[\"null\",\"double\"],\"default\":null},{\"name\":\"OFDM_ANI_LEVEL_ADJUSTED\",\"type\":[\"null\",\"int\"],\"default\":null}]}"
   },
   {
-    "subject": "test-protobuf",
+    "subject": "test-avro-with-refs",
     "version": 2,
     "id": 2,
+    "references": [
+      {
+        "name": "customer",
+        "subject": "some-subject",
+        "version": 2
+      }
+    ],
+    "schema": "{\"type\":\"record\",\"name\":\"address\",\"fields\":[{\"name\":\"field1\",\"type\":\"string\"},{\"name\":\"field2\",\"type\":\"customer\"}]}"
+  },
+  {
+    "subject": "test-protobuf",
+    "version": 1,
+    "id": 3,
     "schema": "syntax = \"proto3\";\npackage com.mycorp.mynamespace;\n",
     "schemaType": "PROTOBUF"
   },
   {
     "subject": "test-json",
     "version": 3,
-    "id": 3,
+    "id": 4,
     "schema": "{\"name\":\"my-foo\",\"realName\":\"my-foobar\"}",
     "schemaType": "JSON"
   }


### PR DESCRIPTION
### What is the purpose of this change?
In order to support scanning thousands of schema records from confluent, we need to switch to apache http. 
By this switch we get less latency (e.g. for 10k records, 3 seconds with apache http instead of 100 seconds with webflux)

Also when using webflux the heap memory usage looked like this:
![scan 10000 schemas , EMA , took 102 sec](https://user-images.githubusercontent.com/40175386/230925245-037f8086-77af-40c7-af0a-c99ce345afd3.png)

However, when using apache http library we get very low hit on heap:
![scan 10k schemas , EMA , took 3 sec](https://user-images.githubusercontent.com/40175386/230925463-859c6702-2aff-4af3-8167-8446c831dadf.png)


### How was this change implemented?
Introduced a new dependency `httpclient` and switched the code to use that API client instead of webflux.
Also updated the `ConfluentSchemaRegistrySchemaEvent` object to support schemaType and references values.

### How was this change tested?
Manual testing (above screenshots) and updated unit tests.

### Is there anything the reviewers should focus on/be aware of?
Nope.