### PR TITLE
Updated README.md to describe usage of EMA connection file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ The steps for generating the connection file are listed over here : https://docs
 Replace the application.yml present in the location : event-management-agent/service/application/src/main/resources with the EMA connection file. </br>
 For security considerations, passwords should be configured through environment variables or in other secure manner.
 
-```
 
 ### Cloning and Building
 

--- a/README.md
+++ b/README.md
@@ -67,16 +67,12 @@ The Event Management Agent was tested to run with
 
 ### Spring-boot properties
 
-These properties are required to run this spring boot application in cloud mode. Update the following properties in the
-application.yml file
+Specific properties are required to run this spring boot application in cloud mode. </br>
+These properties are defined in the connection file that can be downloaded from the Event Portal's Event Management Agent definition. </br>
+The steps for generating the connection file are listed over here : https://docs.solace.com/Cloud/Event-Portal/event-portal-collect-runtime-data.htm#creating_connection_file </br>
+Replace the application.yml present in the location : event-management-agent/service/application/src/main/resources with the EMA connection file. </br>
+For security considerations, passwords should be configured through environment variables or in other secure manner.
 
-```
-eventPortal.gateway.messaging.connections.url = <secure smf host and port> example  tcps://<host>:<port>
-eventPortal.gateway.messaging.connections.msgVpn = <your vpn>
-eventPortal.gateway.messaging.connections.users.name= <your name>
-eventPortal.gateway.messaging.connections.users.username = <your username>
-eventPortal.gateway.messaging.connections.users.password = <your password>
-eventPortal.gateway.messaging.connections.users.clientName= <your client name>
 ```
 
 ### Cloning and Building


### PR DESCRIPTION
### What is the purpose of this change?
The documentation step instructing on how to setup and provide the application properties required for running the Event management agent application was incorrect.
It does not detail on how to specify the brokers that should be connected to for the scanning process.

### How was this change implemented?
The documentation change specifies that the connection file that is downloaded from the Event Portal's Event Management Agent screen should be used as the application.yml.
A link to detailed instructions on how to setup and get the connection file is also provided.
The change also specifies that the password for the broker connection need to be provided as environment variables or other secure manner inline with the enterprise's standards and practices.

### How was this change tested?
The steps that are detailed in the change have been verified manually by me and they work.

### Is there anything the reviewers should focus on/be aware of?
Please consider the impact of this documentation on formatting of the agent config file. Since the format is expected to change shortly with the inclusion of confluent schema registry configurations, please consider how this description will impact the setup and also if it will have to be changed after this release.