### PR TITLE
DATAGO-50709: add support for confluent authentication scenarios

### DIFF
--- a/docs/rest.md
+++ b/docs/rest.md
@@ -252,6 +252,146 @@ plugins:
           url: <host and port> example:  http://<host>:<port>
 ```
 
+### Confluent Schema Registry Connection - Basic Authentication
+
+The following environment variable needs to be exported:
+
+- ${CONFLUENT_USERNAME}
+- ${CONFLUENT_PASSWORD}
+
+
+```
+plugins:
+  resources:
+    - id: <Confluent Schema Registry resource id>
+      name: <Confluent Schema Registry name>
+      type: confluent_schema_registry
+      relatedServices: list of kafka services linked to this schema registry, example: [ id1,id2,id3 ]
+      connections:
+        - name: <Confluent Schema Registry connection name>
+          url: <host and port> example:  http://<host>:<port>
+          authentication:
+            - protocol: BASIC
+              credentials:
+                - properties:
+                    - name: username
+                      value: ${CONFLUENT_USERNAME}
+                    - name: password
+                      value: ${CONFLUENT_PASSWORD}
+                  source: ENVIRONMENT_VARIABLE
+                  operations:
+                    - name: ALL
+```
+
+### Confluent Schema Registry Connection - Basic Authentication With SSL
+
+The following environment variable needs to be exported:
+
+- ${CONFLUENT_USERNAME}
+- ${CONFLUENT_PASSWORD}
+- ${TRUSTSTORE_LOCATION}
+- ${TRUSTSTORE_PASSWORD}
+
+
+```
+plugins:
+  resources:
+    - id: <Confluent Schema Registry resource id>
+      name: <Confluent Schema Registry name>
+      type: confluent_schema_registry
+      relatedServices: list of kafka services linked to this schema registry, example: [ id1,id2,id3 ]
+      connections:
+        - name: <Confluent Schema Registry connection name>
+          url: <host and port> example:  https://<host>:<port>
+          authentication:
+            - protocol: BASIC_SSL
+              credentials:
+                - properties:
+                    - name: username
+                      value: ${CONFLUENT_USERNAME}
+                    - name: password
+                      value: ${CONFLUENT_PASSWORD}
+                    - ssl.truststore.location
+                      value: ${TRUSTSTORE_LOCATION}
+                    - name: ssl.truststore.password
+                      value: ${TRUSTSTORE_PASSWORD}
+                  source: ENVIRONMENT_VARIABLE
+                  operations:
+                    - name: ALL
+```
+
+### Confluent Schema Registry Connection - SSL with TrustStore
+
+The following environment variable needs to be exported:
+
+- ${TRUSTSTORE_LOCATION}
+- ${TRUSTSTORE_PASSWORD}
+
+
+```
+plugins:
+  resources:
+    - id: <Confluent Schema Registry resource id>
+      name: <Confluent Schema Registry name>
+      type: confluent_schema_registry
+      relatedServices: list of kafka services linked to this schema registry, example: [ id1,id2,id3 ]
+      connections:
+        - name: <Confluent Schema Registry connection name>
+          url: <host and port> example:  https://<host>:<port>
+          authentication:
+            - protocol: TLS
+              credentials:
+                - properties:
+                    - ssl.truststore.location
+                      value: ${TRUSTSTORE_LOCATION}
+                    - name: ssl.truststore.password
+                      value: ${TRUSTSTORE_PASSWORD}
+                  source: ENVIRONMENT_VARIABLE
+                  operations:
+                    - name: ALL
+```
+
+### Confluent Schema Registry Connection - SSL with TrustStore and KeyStore
+
+The following environment variable needs to be exported:
+
+- ${TRUSTSTORE_LOCATION}
+- ${TRUSTSTORE_PASSWORD}
+- ${KEYSTORE_LOCATION}
+- ${KEYSTORE_PASSWORD}
+- ${KEY_PASSWORD}
+
+
+```
+plugins:
+  resources:
+    - id: <Confluent Schema Registry resource id>
+      name: <Confluent Schema Registry name>
+      type: confluent_schema_registry
+      relatedServices: list of kafka services linked to this schema registry, example: [ id1,id2,id3 ]
+      connections:
+        - name: <Confluent Schema Registry connection name>
+          url: <host and port> example:  https://<host>:<port>
+          authentication:
+            - protocol: TLS
+              credentials:
+                - properties:
+                    - ssl.truststore.location
+                      value: ${TRUSTSTORE_LOCATION}
+                    - name: ssl.truststore.password
+                      value: ${TRUSTSTORE_PASSWORD}
+                    - name: ssl.keystore.password
+                      value: ${KEYSTORE_PASSWORD}
+                    - name: ssl.keystore.location
+                      value: ${KEYSTORE_LOCATION}
+                    - name: ssl.key.password
+                      value: ${KEY_PASSWORD}
+                  source: ENVIRONMENT_VARIABLE
+                  operations:
+                    - name: ALL
+```
+
+
 ### Environment Variables
 
 When using environment variables, they must all be exported into the environment, otherwise the value will be empty.

--- a/service/application/src/main/resources/application.yml
+++ b/service/application/src/main/resources/application.yml
@@ -67,14 +67,107 @@ eventPortal:
 
 #plugins:
 #  resources:
-#    # Confluent Schema Registry example
+#    # Confluent Schema Registry No Auth example
 #    - id: someConfluentId
 #      name: no auth confluent example
 #      type: confluent_schema_registry
-#      relatedServices: [ id1,id2,id3 ]
+#      relatedServices:
+#        - id1
+#        - id2
+#        - id3
 #      connections:
 #        - name: myConfluentNoAuth
 #          url: ${CONFLUENT_SCHEMA_REGISTRY_URL}
+#    # Confluent Schema Registry Basic Auth example
+#    - id: someConfluentId
+#      name: no auth confluent example
+#      type: confluent_schema_registry
+#      relatedServices:
+#        - id1
+#      connections:
+#        - name: myConfluentBasicAuth
+#          url: ${CONFLUENT_SCHEMA_REGISTRY_URL}
+#          authentication:
+#            - protocol: BASIC
+#              credentials:
+#                - properties:
+#                    - name: username
+#                      value: ${CONFLUENT_USERNAME}
+#                    - name: password
+#                      value: ${CONFLUENT_PASSWORD}
+#                  source: ENVIRONMENT_VARIABLE
+#                  operations:
+#                    - name: ALL
+#    # Confluent Schema Registry Basic Auth With SSL example
+#    - id: someConfluentId
+#      name: no auth confluent example
+#      type: confluent_schema_registry
+#      relatedServices:
+#        - id1
+#      connections:
+#        - name: myConfluentBasicAuthWithSSL
+#          url: ${CONFLUENT_SCHEMA_REGISTRY_URL}
+#          authentication:
+#            - protocol: BASIC_SSL
+#              credentials:
+#                - properties:
+#                    - name: username
+#                      value: ${CONFLUENT_USERNAME}
+#                    - name: password
+#                      value: ${CONFLUENT_PASSWORD}
+#                    - name: ssl.truststore.location
+#                      value: ${TRUSTSTORE_LOCATION}
+#                    - name: ssl.truststore.password
+#                      value: ${TRUSTSTORE_PASSWORD}
+#                  source: ENVIRONMENT_VARIABLE
+#                  operations:
+#                    - name: ALL
+#    # Confluent Schema Registry TLS example
+#    - id: someConfluentId
+#      name: no auth confluent example
+#      type: confluent_schema_registry
+#      relatedServices:
+#        - id1
+#      connections:
+#        - name: myConfluentTLS
+#          url: ${CONFLUENT_SCHEMA_REGISTRY_URL}
+#          authentication:
+#            - protocol: TLS
+#              credentials:
+#                - properties:
+#                    - name: ssl.truststore.location
+#                      value: ${TRUSTSTORE_LOCATION}
+#                    - name: ssl.truststore.password
+#                      value: ${TRUSTSTORE_PASSWORD}
+#                  source: ENVIRONMENT_VARIABLE
+#                  operations:
+#                    - name: ALL
+#    # Confluent Schema Registry MTLS example
+#    - id: someConfluentId
+#      name: no auth confluent example
+#      type: confluent_schema_registry
+#      relatedServices:
+#        - id1
+#      connections:
+#        - name: myConfluentMTLS
+#          url: ${CONFLUENT_SCHEMA_REGISTRY_URL}
+#          authentication:
+#            - protocol: MTLS
+#              credentials:
+#                - properties:
+#                    - name: ssl.truststore.location
+#                      value: ${TRUSTSTORE_LOCATION}
+#                    - name: ssl.truststore.password
+#                      value: ${TRUSTSTORE_PASSWORD}
+#                    - name: ssl.keystore.password
+#                      value: ${KEYSTORE_PASSWORD}
+#                    - name: ssl.keystore.location
+#                      value: ${KEYSTORE_LOCATION}
+#                    - name: ssl.key.password
+#                      value: ${KEY_PASSWORD}
+#                  source: ENVIRONMENT_VARIABLE
+#                  operations:
+#                    - name: ALL
 #    # Solace example
 #    - id: solaceDefaultService
 #      type: SOLACE

--- a/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/manager/client/ConfluentSchemaRegistryClientManagerImpl.java
+++ b/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/manager/client/ConfluentSchemaRegistryClientManagerImpl.java
@@ -4,10 +4,30 @@ import com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.
 import com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.processor.schema.HttpClient;
 import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
 import com.solace.maas.ep.event.management.agent.plugin.manager.client.MessagingServiceClientManager;
+import com.solace.maas.ep.event.management.agent.plugin.messagingService.event.AuthenticationDetailsEvent;
 import com.solace.maas.ep.event.management.agent.plugin.messagingService.event.ConnectionDetailsEvent;
+import com.solace.maas.ep.event.management.agent.plugin.util.MessagingServiceConfigurationUtil;
+import com.solace.maas.ep.event.management.agent.plugin.util.UriUtil;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+
+import javax.net.ssl.SSLContext;
+import java.io.File;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
 
 @Slf4j
 @ExcludeFromJacocoGeneratedReport
@@ -16,11 +36,78 @@ public class ConfluentSchemaRegistryClientManagerImpl implements MessagingServic
     @Override
     public ConfluentSchemaRegistryHttp getClient(ConnectionDetailsEvent connectionDetailsEvent) {
         log.debug("creating Confluent Schema Registry client for: {}", connectionDetailsEvent.getMessagingServiceId());
+
         HttpClient httpClient = HttpClient.builder()
-                .webClient(HttpClientBuilder.create().build())
+                .webClient(buildClient(connectionDetailsEvent))
                 .connectionUrl(connectionDetailsEvent.getUrl())
                 .build();
         log.debug("Confluent Schema Registry client created for {}.", connectionDetailsEvent.getMessagingServiceId());
         return new ConfluentSchemaRegistryHttp(httpClient);
+    }
+
+    private CloseableHttpClient buildClient(ConnectionDetailsEvent connectionDetailsEvent) {
+
+        HttpClientBuilder clientBuilder = HttpClients.custom();
+
+        Optional<AuthenticationDetailsEvent> authenticationDetailsEvent =
+                connectionDetailsEvent.getAuthenticationDetails().stream().findFirst();
+
+        authenticationDetailsEvent.ifPresent(auth -> {
+            Map<String, String> credentialProperties = MessagingServiceConfigurationUtil.getCredentialsProperties(auth);
+
+            if (StringUtils.isNotEmpty(credentialProperties.get("username"))) {
+                CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                URI uri = UriUtil.getURI(connectionDetailsEvent.getUrl());
+                AuthScope authScope = new AuthScope(uri.getHost(), uri.getPort());
+                UsernamePasswordCredentials usernamePasswordCredentials =
+                        new UsernamePasswordCredentials(MessagingServiceConfigurationUtil.getUsername(auth),
+                                MessagingServiceConfigurationUtil.getPassword(auth));
+                credentialsProvider.setCredentials(authScope, usernamePasswordCredentials);
+                clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+            }
+
+            if (credentialProperties.containsKey("ssl.truststore.location")) {
+                SSLContextBuilder SSLBuilder = SSLContexts.custom();
+
+                File trustStoreFile = new File(credentialProperties.get("ssl.truststore.location"));
+                try {
+                    SSLBuilder.loadTrustMaterial(trustStoreFile,
+                            credentialProperties.get("ssl.truststore.password").toCharArray());
+                } catch (Exception e) {
+                    log.error("Exception occurred during loading truststore credentials of properties {}\nexception: {}",
+                            credentialProperties,
+                            e.getMessage());
+                    e.printStackTrace();
+                }
+
+                if (credentialProperties.containsKey("ssl.keystore.location")) {
+                    File keyStoreFile = new File(credentialProperties.get("ssl.keystore.location"));
+                    try {
+                        SSLBuilder.loadKeyMaterial(keyStoreFile,
+                                credentialProperties.get("ssl.keystore.password").toCharArray(),
+                                credentialProperties.get("ssl.key.password").toCharArray());
+                    } catch (Exception e) {
+                        log.error("Exception occurred during loading keystore credentials of properties {}\nexception: {}",
+                                credentialProperties,
+                                e.getMessage());
+                        e.printStackTrace();
+                    }
+                }
+
+                try {
+                    SSLContext sslcontext = SSLBuilder.build();
+                    SSLConnectionSocketFactory sslConnectionSocketFactory =
+                            new SSLConnectionSocketFactory(sslcontext, new NoopHostnameVerifier());
+
+                    clientBuilder.setSSLSocketFactory(sslConnectionSocketFactory);
+                } catch (Exception e) {
+                    log.error("Exception occurred during setting SSL configurations, exception was: {}",
+                            e.getMessage());
+                    e.printStackTrace();
+                }
+            }
+        });
+
+        return clientBuilder.build();
     }
 }

--- a/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/processor/schema/ConfluentSchemaRegistryHttp.java
+++ b/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/processor/schema/ConfluentSchemaRegistryHttp.java
@@ -1,13 +1,12 @@
 package com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.processor.schema;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.exception.ClientException;
-import com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.exception.URIException;
 import com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.processor.event.ConfluentSchemaRegistrySchemaEvent;
 import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
+import com.solace.maas.ep.event.management.agent.plugin.util.UriUtil;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpEntity;
@@ -18,7 +17,6 @@ import org.springframework.http.HttpStatus;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 
 @ExcludeFromJacocoGeneratedReport
@@ -36,29 +34,18 @@ public class ConfluentSchemaRegistryHttp {
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
-    public List<ConfluentSchemaRegistrySchemaEvent> getSchemas() throws JsonProcessingException {
+    public List<ConfluentSchemaRegistrySchemaEvent> getSchemas() throws Exception {
         String response;
-        try {
-            response = getResponse(getUri(GET_ALL_SCHEMAS));
-            return objectMapper.readValue(response, new TypeReference<>() {
-            });
-        } catch (ClientException e) {
-            throw (e);
-        }
+        response = getResponse(getUri(GET_ALL_SCHEMAS));
+        return objectMapper.readValue(response, new TypeReference<>() {
+        });
     }
 
     private URI getUri(String path) {
-        URI uri;
-        try {
-            uri = new URI(httpClient.getConnectionUrl() + path);
-        } catch (URISyntaxException e) {
-            log.error("URI error for {}", httpClient.getConnectionUrl(), e);
-            throw new URIException(String.format("Could not construct URL from %s", httpClient.getConnectionUrl()), e);
-        }
-        return uri;
+        return UriUtil.getURI(httpClient.getConnectionUrl() + path);
     }
 
-    private String getResponse(URI uri) {
+    private String getResponse(URI uri) throws IOException {
         HttpGet getData = new HttpGet();
         getData.setURI(uri);
         try (CloseableHttpResponse response = httpClient.getWebClient().execute(getData)) {
@@ -72,9 +59,6 @@ public class ConfluentSchemaRegistryHttp {
             }
             HttpEntity entity = response.getEntity();
             return EntityUtils.toString(entity);
-        } catch (IOException e) {
-            e.printStackTrace();
         }
-        return null;
     }
 }

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/exception/URIException.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/exception/URIException.java
@@ -1,4 +1,4 @@
-package com.solace.maas.ep.event.management.agent.plugin.confluentSchemaRegistry.exception;
+package com.solace.maas.ep.event.management.agent.plugin.exception;
 
 public class URIException extends RuntimeException {
     public URIException() {

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/util/MessagingServiceConfigurationUtil.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/util/MessagingServiceConfigurationUtil.java
@@ -5,7 +5,10 @@ import com.solace.maas.ep.event.management.agent.plugin.messagingService.event.C
 import com.solace.maas.ep.event.management.agent.plugin.messagingService.event.EventProperty;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class MessagingServiceConfigurationUtil {
     public static <T extends EventProperty> String getProperty(List<T> properties, String name) {
@@ -34,6 +37,16 @@ public class MessagingServiceConfigurationUtil {
         return authenticationDetailsEvent.getCredentials().stream()
                 .findFirst().
                 map(credential -> getProperty(credential.getProperties(), "password"))
+                .orElse(null);
+    }
+
+    public static Map<String, String> getCredentialsProperties(AuthenticationDetailsEvent authenticationDetailsEvent) {
+        return authenticationDetailsEvent.getCredentials().stream()
+                .findFirst().
+                map(credential -> credential.getProperties()
+                        .stream()
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toMap(EventProperty::getName, EventProperty::getValue)))
                 .orElse(null);
     }
 }

--- a/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/util/UriUtil.java
+++ b/service/plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/util/UriUtil.java
@@ -1,0 +1,21 @@
+package com.solace.maas.ep.event.management.agent.plugin.util;
+
+import com.solace.maas.ep.event.management.agent.plugin.exception.URIException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@Slf4j
+public class UriUtil {
+    public static URI getURI(String url) {
+        URI uri;
+        try {
+            uri = new URI(url);
+        } catch (URISyntaxException e) {
+            log.error("URI error for {}", url, e);
+            throw new URIException(String.format("Could not construct URI from %s", url), e);
+        }
+        return uri;
+    }
+}

--- a/service/solace-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/solace/processor/semp/SolaceHttpSemp.java
+++ b/service/solace-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/solace/processor/semp/SolaceHttpSemp.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
+import com.solace.maas.ep.event.management.agent.plugin.util.UriUtil;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -17,7 +18,6 @@ import org.springframework.web.util.UriBuilder;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -159,14 +159,7 @@ public class SolaceHttpSemp {
     }
 
     private URI getSempUri() {
-        URI sempUri = null;
-        try {
-            sempUri = new URI(sempClient.getConnectionUrl());
-        } catch (URISyntaxException e) {
-            log.error("URI error for {}", sempClient.getConnectionUrl(), e);
-            throw new RuntimeException(String.format("Could not construct URL from %s", sempClient.getConnectionUrl()), e);
-        }
-        return sempUri;
+        return UriUtil.getURI(sempClient.getConnectionUrl());
     }
 
     private void getSempListRequest(List<Map<String, Object>> list, Function<UriBuilder, URI> uriMethod) throws


### PR DESCRIPTION
### What is the purpose of this change?
To support different authentication scenarios for confluent schema registry

### How was this change implemented?
By updating the HttpClient details for ConfluentSchemaRegistry plugin

### How was this change tested?
Manually for each of the scenarios. The demo videos are here https://solacedotcom.slack.com/archives/C04LVH340AU/p1681750857717999

### Is there anything the reviewers should focus on/be aware of?
Nada