### PR TITLE
Added instructions for offline discovery import

### DIFF
--- a/docs/rest.md
+++ b/docs/rest.md
@@ -604,7 +604,7 @@ In essence, you will perform a scan from one agent, export it, and upload it to 
 ### Requirements
 - Source Configuration (off-line):
     - EMA configuration (e.g. `your-source-config.yml`)
-    - Stand-alone setting path: `eventPortal.gateway.messaging.standAlone: true`
+    - Stand-alone setting path: `eventPortal.gateway.messaging.standalone: true`
 - Target Configuration (on-line):
     - EMA configuration (e.g. `your-target-config.yml`)
 - Retain the following settings from the EMA for **target** configuration:
@@ -615,14 +615,14 @@ In essence, you will perform a scan from one agent, export it, and upload it to 
 1. Execute source message service scan
     1. Initiate the source scan from EMA REST API; e.g.:<br>
         ```bash
-        curl -H "Content-Type: application/json" -X POST http://localhost:8180/api/v2/ema/messagingServices/{msgServiceId}/scan -d '{"scanTypes": ["KAKFA_ALL"], "destinations":["FILE_WRITER"]}'
+        curl -H "Content-Type: application/json" -X POST http://localhost:8180/api/v2/ema/resources/${msgServiceId}/scan -d '{"scanTypes": ["KAKFA_ALL"], "destinations":["FILE_WRITER"]}'
         ```
     2. Collect the scan ID from the REST return body or the EMA logs. You will need this value for the next step.
         1. The return body (if successful): `Scan request [abc5i21b5g4]: Scan started`
 2. Export the source scan bundle from the Event Management Agent using the EMA REST API
-        ```bash
-        curl -H "Content-Type: application/json" -X GET http://localhost:8180/api/v2/ema/resources/export/${YOUR_SCAN_ID}/zip --output {file_name.zip}
-        ```
+    ```bash
+    curl -H "Content-Type: application/json" -X GET http://localhost:8180/api/v2/ema/resources/export/${YOUR_SCAN_ID}/zip --output {file_name.zip}
+    ```
 3. Modify the source scan bundle to suit the target messaging service
     1. You need to modify the META_INF.json file in the exported bundle. make a working directory and extract:
         ```bash

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -594,3 +594,58 @@ A new file with the following naming convention
 curl --location --request POST 'http://localhost:8180/api/v2/ema/resources/import' \
 --form 'file=@"{full path to the .zip file}'
 ```
+
+## Manual Import of Off-Line Agent Discovery
+The results of a scan run against one messaging service may be uploaded for audit and import to another messaging service defined in Event Portal. 
+
+### Procedure
+In essence, you will perform a scan from one agent, export it, and upload it to Event Portal using another agent. However, the exported data contains identifiers specific to the agent that performed the scan. These identifiers must be modified to suit the agent performing the upload, and modified to the correct messaging service.
+
+### Requirements
+- Source Configuration (off-line):
+    - EMA configuration (e.g. `your-source-config.yml`)
+    - Stand-alone setting path: `eventPortal.gateway.messaging.standAlone: true`
+- Target Configuration (on-line):
+    - EMA configuration (e.g. `your-target-config.yml`)
+- Retain the following settings from the EMA for **target** configuration:
+    - **messagingServiceId** - Path in EMA config: `plugins.resources.id`
+    - **emaId** - Path in EMA config: `eventPortal.runtimeAgentId`
+
+### Detailed Procedure
+1. Execute source message service scan
+    1. Initiate the source scan from EMA REST API; e.g.:<br>
+        ```bash
+        curl -H "Content-Type: application/json" -X POST http://localhost:8180/api/v2/ema/messagingServices/{msgServiceId}/scan -d '{"scanTypes": ["KAKFA_ALL"], "destinations":["FILE_WRITER"]}'
+        ```
+    2. Collect the scan ID from the REST return body or the EMA logs. You will need this value for the next step.
+        1. The return body (if successful): `Scan request [abc5i21b5g4]: Scan started`
+2. Export the source scan bundle from the Event Management Agent using the EMA REST API
+        ```bash
+        curl -H "Content-Type: application/json" -X GET http://localhost:8180/api/v2/ema/resources/export/${YOUR_SCAN_ID}/zip --output {file_name.zip}
+        ```
+3. Modify the source scan bundle to suit the target messaging service
+    1. You need to modify the META_INF.json file in the exported bundle. make a working directory and extract:
+        ```bash
+        mkdir temp
+        cp file_name.zip temp/
+
+        cd temp
+        unzip file_name.zip
+        ```
+    2. Modify META_INF.json file using your favorite editor. The following values must be set to values defined for the target configuration:
+        1. `messagingServiceId`
+        2. `emaId`
+        3. Value of `scanId` should be set to something unique. This is to prevent conflicts.<br>
+            e.g. "scanId": "u5nb56a6ea0" --> "scanId": "xyzb56a6ea0" (Just needs to be unique)
+    3. Re-zip the scan package file
+        ```bash
+        ## Update the META_INF.json in the zip file
+        zip file_name.zip META_INF.json
+        ```
+4. Upload the scan file to the target
+    1. If you are using two separate EMA configuration files, one for the source scan and one for the target upload (which you probably are), you will likely need to make sure that configuration file for the target EMA instance is active. Such as stop the Event Management Agent and re-run specifying the alternate target.
+    2. Execute the upload<br>
+        ```bash
+        curl --location --request POST 'http://localhost:8180/api/v2/ema/resources/import' \
+            --form 'file=@file_name.zip'```
+5. Finally, check Event Portal and your Modeled Event Mesh to view the Audit Results

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -647,5 +647,6 @@ In essence, you will perform a scan from one agent, export it, and upload it to 
     2. Execute the upload<br>
         ```bash
         curl --location --request POST 'http://localhost:8180/api/v2/ema/resources/import' \
-            --form 'file=@file_name.zip'```
+            --form 'file=@file_name.zip'
+        ```
 5. Finally, check Event Portal and your Modeled Event Mesh to view the Audit Results


### PR DESCRIPTION
### What is the purpose of this change?

Provide more detailed instructions for importing scan output from off-line agents into Event Portal. Including instructions for modifying IDs associated with the original scan to the target agent/service.

### How was this change implemented?

Updated docs/rest.md after "manual import"

### How was this change tested?

N/A - Documentation Only

### Is there anything the reviewers should focus on/be aware of?

    ...
