### PR TITLE
DATAGO-54188: Fix the type of id and version

### DIFF
--- a/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/processor/event/ConfluentSchemaRegistrySchemaEvent.java
+++ b/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/processor/event/ConfluentSchemaRegistrySchemaEvent.java
@@ -14,8 +14,8 @@ import java.util.List;
 @Builder
 public class ConfluentSchemaRegistrySchemaEvent implements Serializable {
     private String subject;
-    private String version;
-    private String id;
+    private Integer version;
+    private Integer id;
     private List<ConfluentSchemaRegistrySchemaReference> references;
     private String schemaType;
     private String schema;

--- a/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/processor/event/ConfluentSchemaRegistrySchemaReference.java
+++ b/service/confluentSchemaRegistry-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/processor/event/ConfluentSchemaRegistrySchemaReference.java
@@ -14,5 +14,5 @@ import java.io.Serializable;
 public class ConfluentSchemaRegistrySchemaReference implements Serializable {
     private String name;
     private String subject;
-    private String version;
+    private Integer version;
 }

--- a/service/confluentSchemaRegistry-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/manager/processor/ConfluentSchemaRegistryClientTests.java
+++ b/service/confluentSchemaRegistry-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/confluentSchemaRegistry/manager/processor/ConfluentSchemaRegistryClientTests.java
@@ -86,6 +86,11 @@ class ConfluentSchemaRegistryClientTests {
         assertNotNull(confluentSchemaRegistrySchemaEventList.get(3).getSchemaType());
 
         assertThat(confluentSchemaRegistrySchemaEventList.get(1).getReferences()).hasSize(1);
+
+        //Data type for id and version and reference-version is Integer
+        assertThat(confluentSchemaRegistrySchemaEventList.get(1).getId()).isInstanceOf(Integer.class);
+        assertThat(confluentSchemaRegistrySchemaEventList.get(1).getVersion()).isInstanceOf(Integer.class);
+        assertThat(confluentSchemaRegistrySchemaEventList.get(1).getReferences().get(0).getVersion()).isInstanceOf(Integer.class);
     }
 
     @SneakyThrows


### PR DESCRIPTION
### What is the purpose of this change?
To match the schema of CSR

### How was this change implemented?
Changed the type of id and version to Integer

### How was this change tested?
UnitTests, and ran the code manually and observed the results saved in ep-core `scan_data` table:
![Screen Shot 2023-04-25 at 10 38 56 AM](https://user-images.githubusercontent.com/40175386/234313877-efcb2ca7-89b2-475b-bebf-b71ef662b667.png)


### Is there anything the reviewers should focus on/be aware of?
nope
