### PR TITLE
DATAGO-54615:remove all gcr and ecr references from the pom file

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -2,6 +2,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.11</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.solace.maas</groupId>
+    <artifactId>maas-event-management-agent-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>maas-event-management-agent-parent</name>
+    <description>maas-event-management-agent-parent</description>
+    <packaging>pom</packaging>
+
     <modules>
         <module>plugin</module>
         <module>application</module>
@@ -11,23 +24,9 @@
         <module>local-storage-plugin</module>
         <module>confluentSchemaRegistry-plugin</module>
     </modules>
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.6</version>
-        <relativePath/> <!-- lookup parent from repository -->
-    </parent>
-    <groupId>com.solace.maas</groupId>
-    <artifactId>maas-event-management-agent-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
-    <name>maas-event-management-agent-parent</name>
-    <description>maas-event-management-agent-parent</description>
-    <packaging>pom</packaging>
     <properties>
         <java.version>11</java.version>
         <project.git.directory>${project.basedir}/../.git</project.git.directory>
-        <awsDockerRepo>868978040651.dkr.ecr.us-east-1.amazonaws.com</awsDockerRepo>
-        <gcpDockerRepo>gcr.io/stellar-arcadia-205014</gcpDockerRepo>
         <dockerTimestamp>${maven.build.timestamp}</dockerTimestamp>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
         <docker.parent.version>1.2.1</docker.parent.version>
@@ -289,97 +288,6 @@
                             </goals>
                         </execution>
                     </executions>
-                </plugin>
-                <plugin>
-                    <groupId>com.spotify</groupId>
-                    <artifactId>dockerfile-maven-plugin</artifactId>
-                    <version>1.4.10</version>
-                    <executions>
-                        <execution>
-                            <id>aws-githash</id>
-                            <phase>none</phase>
-                            <goals>
-                                <goal>build</goal>
-                                <goal>push</goal>
-                            </goals>
-                            <configuration>
-                                <tag>${dockerVersion}-${git.commit.id.abbrev}</tag>
-                                <repository>${awsDockerRepo}/${project.artifactId}</repository>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>gcp-githash</id>
-                            <phase>none</phase>
-                            <goals>
-                                <goal>build</goal>
-                                <goal>push</goal>
-                            </goals>
-                            <configuration>
-                                <tag>${dockerVersion}-${git.commit.id.abbrev}</tag>
-                                <repository>${gcpDockerRepo}/${project.artifactId}</repository>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>aws-version</id>
-                            <phase>none</phase>
-                            <goals>
-                                <goal>tag</goal>
-                                <goal>push</goal>
-                            </goals>
-                            <configuration>
-                                <tag>${dockerVersion}</tag>
-                                <repository>${awsDockerRepo}/${project.artifactId}</repository>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>gcp-version</id>
-                            <phase>none</phase>
-                            <goals>
-                                <goal>tag</goal>
-                                <goal>push</goal>
-                            </goals>
-                            <configuration>
-                                <tag>${dockerVersion}</tag>
-                                <repository>${gcpDockerRepo}/${project.artifactId}</repository>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>aws-githash-tag</id>
-                            <phase>none</phase>
-                            <goals>
-                                <goal>tag</goal>
-                                <goal>push</goal>
-                            </goals>
-                            <configuration>
-                                <tag>${dockerVersion}-${git.commit.id.abbrev}</tag>
-                                <repository>${awsDockerRepo}/${project.artifactId}</repository>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>gcp-githash-tag</id>
-                            <phase>none</phase>
-                            <goals>
-                                <goal>tag</goal>
-                                <goal>push</goal>
-                            </goals>
-                            <configuration>
-                                <tag>${dockerVersion}-${git.commit.id.abbrev}</tag>
-                                <repository>${gcpDockerRepo}/${project.artifactId}</repository>
-                            </configuration>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <dockerfile>${project.build.directory}/Dockerfile</dockerfile>
-                        <skipDockerInfo>true</skipDockerInfo>
-                        <buildArgs>
-                            <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
-                            <BASE_IMAGE>868978040651.dkr.ecr.us-east-1.amazonaws.com/event-management-agent-base:0.0.1
-                            </BASE_IMAGE>
-                            <MAAS_GITHASH>${dockerVersion}-${git.commit.id.abbrev}</MAAS_GITHASH>
-                            <MAAS_BRANCH>${git.branch}</MAAS_BRANCH>
-                            <MAAS_BUILD_TIMESTAMP>${dockerTimestamp}</MAAS_BUILD_TIMESTAMP>
-                        </buildArgs>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION

### What is the purpose of this change?
- simple refactoring of pom file to be consistent with other projects
- renaming the version to 1.0.0-SNAPSHOT
- updated to the latest patch version of spring-boot 2.7 that is supported
- removing aws/gcr references in the pom file because the first phase is to create a jar file only.

### How was this change implemented?
- simple pom file changes


### How was this change tested?
- mvn clean compile worked with no issues

### Is there anything the reviewers should focus on/be aware of?
- not that i am aware of
