### PR TITLE
Add concurrentcy/timeout and path filtering to build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,9 +3,9 @@ on:
   push:
     branches:
       - main
-      paths-ignore:
-        - '.gitignore'
-        - '.github/**'
+    paths-ignore:
+      - '.gitignore'
+      - '.github/**'
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,14 +2,22 @@ name: Build
 on:
   push:
     branches:
-      main
+      - main
+      paths-ignore:
+        - '.gitignore'
+        - '.github/**'
   pull_request:
     types: [opened, synchronize, reopened]
+
+  concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
   Test_Build:
     name: Run Tests and Deploy
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,9 +9,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-  concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   Test_Build:


### PR DESCRIPTION
### What is the purpose of this change?
Improving build workflow to:
- have a timeout of 20 minutes
- disable concurrent runs for the same PR (or main branch)
- not triggering the build for changes in .github folder