### PR TITLE
Adding Whitesource Scan to Build Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
           export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
           echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
           echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-          if [[ $GITHUB_EVENT_NAME != "pull_request" && $GITHUB_REF_NAME=="main" ]]; then
+          if [[ $GITHUB_REF_NAME=="main" ]]; then
             export WHITESOURCE_SCAN=true
             export GITHUB_PACKAGES_DEPLOY=true
           else

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
 #          mvn -B $SKIP_FLAGS_ALL_TESTS \
 #            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_runtime-agent \
 #            --file service/pom.xml
-      - name: Download latest mend/whitesource agent and verify its integrity
+      - name: Download latest Mend/Whitesource Agent
         if: ${{ github.ref == 'refs/heads/add_whitesource' }}
         env:
           unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"
@@ -70,12 +70,14 @@ jobs:
               echo "Integrity check of wss-unified-agent.jar file failed .."
               exit 1
           fi
-      - name: Perform whitesource scan
+      - name: Copy Maven Dependencies
+        run: mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
+      - name: Perform Whitesource Scan
         if: ${{ github.ref == 'refs/heads/add_whitesource' }}
         env:
           WHITESOURCE_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WHITESOURCE_PROJECT_TOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-          TARGET_DIR: "service/application/target"
+          TARGET_DIR: "service/application/target/lib"
         run: java -jar wss-unified-agent.jar -apiKey ${{ env.WHITESOURCE_API_KEY }}   -projectToken ${{ env.WHITESOURCE_PROJECT_TOKEN }} -d  ${{ env.TARGET_DIR }} -logLevel Trace
 
 #      - name: Deploy Artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,15 +37,13 @@ jobs:
           export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
           echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
           echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-          echo "$GITHUB_EVENT_NAME"
-          echo "$GITHUB_REF_NAME"
           if [[ $GITHUB_EVENT_NAME != "pull_request" && $GITHUB_REF_NAME="add_whitesource" ]]; then
-            export MAIN_BRANCH_BUILD=true
+            export WHITESOURCE_SCAN=true
           else
-            export MAIN_BRANCH_BUILD=false
+            export WHITESOURCE_SCAN=false
           fi
-          echo "$MAIN_BRANCH_BUILD"
-          echo "MAIN_BRANCH_BUILD=$MAIN_BRANCH_BUILD" >> $GITHUB_ENV
+          echo "$WHITESOURCE_SCAN"
+          echo "WHITESOURCE_SCAN=$WHITESOURCE_SCAN" >> $GITHUB_ENV
       - run: echo "$MAIN_BRANCH_BUILD"
       - name: test
         if: env.MAIN_BRANCH_BUILD=='true'
@@ -65,34 +63,35 @@ jobs:
 #          mvn -B $SKIP_FLAGS_ALL_TESTS \
 #            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_runtime-agent \
 #            --file service/pom.xml
-#      - name: Download latest Mend/Whitesource Agent
-#        if: ${{ github.ref == 'refs/heads/add_whitesource' }}
-#        env:
-#          unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"
-#          unified_agent_sha_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar.sha256"
-#        run: |
-#          curl -LJOs ${{ env.unified_agent_url }}
-#          sha_from_jar=$(sha256sum  wss-unified-agent.jar | awk '{print $1}')
-#          curl -LJOs ${{ env.unified_agent_sha_url }}
-#          sha_from_file=$(cat wss-unified-agent.jar.sha256 | awk '{print $1}')
-#          echo "sha_from_jar: $sha_from_jar"
-#          echo "sha_from_file: $sha_from_file"
-#          if [[ "$sha_from_file" == "$sha_from_jar" ]]; then
-#              echo "Integrity of the wss-unified-agent.jar file verified .."
-#          else
-#              echo "Integrity check of wss-unified-agent.jar file failed .."
-#              exit 1
-#          fi
-#      - name: Copy Maven Dependencies
-#        run: mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
-#      - name: Whitesource Scan
-##        if: ${{ github.ref == 'refs/heads/add_whitesource' }}
-#        env:
-#          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-#          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-#          TARGET_DIR: "service/application/target/lib"
-#          WS_EXCLUDES: "local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
-#        run: java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel Info
+      - name: Download latest Mend/Whitesource Agent
+        if: env.WHITESOURCE_SCAN=='true'
+        env:
+          unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"
+          unified_agent_sha_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar.sha256"
+        run: |
+          curl -LJOs ${{ env.unified_agent_url }}
+          sha_from_jar=$(sha256sum  wss-unified-agent.jar | awk '{print $1}')
+          curl -LJOs ${{ env.unified_agent_sha_url }}
+          sha_from_file=$(cat wss-unified-agent.jar.sha256 | awk '{print $1}')
+          echo "sha_from_jar: $sha_from_jar"
+          echo "sha_from_file: $sha_from_file"
+          if [[ "$sha_from_file" == "$sha_from_jar" ]]; then
+              echo "Integrity of the wss-unified-agent.jar file verified .."
+          else
+              echo "Integrity check of wss-unified-agent.jar file failed .."
+              exit 1
+          fi
+      - name: Copy Maven Dependencies
+        if: env.WHITESOURCE_SCAN=='true'
+        run: mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
+      - name: Whitesource Scan
+        if: env.WHITESOURCE_SCAN=='true'
+        env:
+          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+          TARGET_DIR: "service/application/target/lib"
+          WS_EXCLUDES: "local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
+        run: java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel Info
 
 #      - name: Deploy Artifacts
 #        if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
           echo "MAIN_BRANCH_BUILD=$MAIN_BRANCH_BUILD" >> $GITHUB_ENV
       - run: echo "$MAIN_BRANCH_BUILD"
       - name: test
-        if: env.MAIN_BRANCH_BUILD
+        if: env.MAIN_BRANCH_BUILD=='true'
         run: "echo yes I am main branch"
 #      - name: Static Code Analysis
 #        run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
           export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
           echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
           echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-          if [[ $GITHUB_EVENT_NAME != "pull_request" && $GITHUB_REF_NAME="main" ]]; then
+          if [[ $GITHUB_EVENT_NAME != "pull_request" && $GITHUB_REF_NAME=="main" ]]; then
             export WHITESOURCE_SCAN=true
             export GITHUB_PACKAGES_DEPLOY=true
           else

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,7 +78,11 @@ jobs:
           WHITESOURCE_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WHITESOURCE_PROJECT_TOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
           TARGET_DIR: "service/application/target/lib"
-        run: java -jar wss-unified-agent.jar -apiKey ${{ env.WHITESOURCE_API_KEY }}   -projectToken ${{ env.WHITESOURCE_PROJECT_TOKEN }} -d  ${{ env.TARGET_DIR }} -logLevel Trace
+          WHITESOURCE_EXCLUDES="local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
+        run: java -jar wss-unified-agent.jar \
+              -apiKey ${{ env.WHITESOURCE_API_KEY }}   -projectToken ${{ env.WHITESOURCE_PROJECT_TOKEN }} \
+              -d  ${{ env.TARGET_DIR }} \
+              -excludes $${{ env.WHITESOURCE_EXCLUDES }} -logLevel info
 
 #      - name: Deploy Artifacts
 #        if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,7 +78,7 @@ jobs:
           WHITESOURCE_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WHITESOURCE_PROJECT_TOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
           TARGET_DIR: "service/application/target/lib"
-          WHITESOURCE_EXCLUDES="local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
+          WHITESOURCE_EXCLUDES: "local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
         run: java -jar wss-unified-agent.jar \
               -apiKey ${{ env.WHITESOURCE_API_KEY }}   -projectToken ${{ env.WHITESOURCE_PROJECT_TOKEN }} \
               -d  ${{ env.TARGET_DIR }} \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: Build
 on:
   push:
     branches:
-      - main
+      - add_whitesource
     paths-ignore:
       - '.gitignore'
       - '.github/**'
@@ -37,24 +37,50 @@ jobs:
           export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
           echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
           echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-      - name: Static Code Analysis
-        run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml
-      - name: Unit Tests
-        run: mvn -B test $SKIP_FLAGS_NON_UNIT_TESTS --file service/pom.xml
+#      - name: Static Code Analysis
+#        run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml
+#      - name: Unit Tests
+#        run: mvn -B test $SKIP_FLAGS_NON_UNIT_TESTS --file service/pom.xml
       - name: Generate Artifacts
         run: |
           mvn install $SKIP_FLAGS_ALL_TESTS --file service/pom.xml
-      - name: Sonar Scan
+#      - name: Sonar Scan
+#        env:
+#          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+#          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+#        run: |
+#          mvn -B $SKIP_FLAGS_ALL_TESTS \
+#            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_runtime-agent \
+#            --file service/pom.xml
+      - name: Download latest mend/whitesource agent and verify its integrity
+        if: ${{ github.ref == 'refs/heads/add_whitesource' }}
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"
+          unified_agent_sha_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar.sha256"
         run: |
-          mvn -B $SKIP_FLAGS_ALL_TESTS \
-            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_runtime-agent \
-            --file service/pom.xml
-      - name: Deploy Artifacts
-        if: ${{ github.ref == 'refs/heads/main' }}
+          curl -LJO ${{ env.unified_agent_url }}
+          sha_from_jar=$(sha256sum  wss-unified-agent.jar | awk '{print $1}')
+          curl -LJO ${{ env.unified_agent_sha_url }}
+          sha_from_file=$(cat wss-unified-agent.jar.sha256 | awk '{print $1}')
+          echo "sha_from_jar: $sha_from_jar"
+          echo "sha_from_file: $sha_from_file"
+          if [[ "$sha_from_file" == "$sha_from_jar" ]]; then
+              echo "Integrity of the wss-unified-agent.jar file verified .."
+          else
+              echo "Integrity check of wss-unified-agent.jar file failed .."
+              exit 1
+          fi
+      - name: Perform whitesource scan
+        if: ${{ github.ref == 'refs/heads/add_whitesource' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mvn deploy $SKIP_FLAGS_ALL_TESTS -Dmaven.install.skip=true --file service/pom.xml
+          WHITESOURCE_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
+          WHITESOURCE_PROJECT_TOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+          TARGET_DIR: "service/application/target"
+        run: java -jar wss-unified-agent.jar -apiKey ${{ env.WHITESOURCE_API_KEY }}   -projectToken ${{ env.WHITESOURCE_PROJECT_TOKEN }} -d  ${{ env.TARGET_DIR }} -logLevel info
+
+#      - name: Deploy Artifacts
+#        if: ${{ github.ref == 'refs/heads/main' }}
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          mvn deploy $SKIP_FLAGS_ALL_TESTS -Dmaven.install.skip=true --file service/pom.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,7 @@ jobs:
         env:
           WHITESOURCE_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WHITESOURCE_PROJECT_TOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-          TARGET_DIR: "service/application/target"
+          TARGET_DIR: "service/kafka-plugin/target"
         run: java -jar wss-unified-agent.jar -apiKey ${{ env.WHITESOURCE_API_KEY }}   -projectToken ${{ env.WHITESOURCE_PROJECT_TOKEN }} -d  ${{ env.TARGET_DIR }} -logLevel info
 
 #      - name: Deploy Artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,8 +37,9 @@ jobs:
           export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
           echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
           echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-          if [ $GITHUB_EVENT_NAME != "pull_request" && $GITHUB_REF_NAME="add_whitesource" ]
-          then
+          echo "$GITHUB_EVENT_NAME"
+          echo "$GITHUB_REF_NAME"
+          if [[ $GITHUB_EVENT_NAME != "pull_request" && $GITHUB_REF_NAME="add_whitesource" ]]; then
             export MAN_BRANCH_BUILD=true
           else
             export MAN_BRANCH_BUILD=false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,8 @@ jobs:
           echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
           echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
           echo "$GITHUB_REF_NAME"
-          if [[ $GITHUB_EVENT_NAME != "pull_request" && $GITHUB_REF_NAME=="main" ]]; then
+          echo "$GITHUB_EVENT_NAME"
+          if [[ $GITHUB_EVENT_NAME != "pull_request" && $GITHUB_REF_NAME == "main" ]]; then
             export WHITESOURCE_SCAN=true
             export GITHUB_PACKAGES_DEPLOY=true
           else
@@ -48,55 +49,55 @@ jobs:
           echo "$WHITESOURCE_SCAN"
           echo "WHITESOURCE_SCAN=$WHITESOURCE_SCAN" >> $GITHUB_ENV
           echo "GITHUB_PACKAGES_DEPLOY=$GITHUB_PACKAGES_DEPLOY" >> $GITHUB_ENV
-      - name: Static Code Analysis
-        run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml
-      - name: Unit Tests
-        run: mvn -B test $SKIP_FLAGS_NON_UNIT_TESTS --file service/pom.xml
-      - name: Generate Artifacts
-        run: |
-          mvn install $SKIP_FLAGS_ALL_TESTS --file service/pom.xml
-      - name: Sonar Scan
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-        run: |
-          mvn -B $SKIP_FLAGS_ALL_TESTS \
-            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_runtime-agent \
-            --file service/pom.xml
-      - name: WhiteSource Scan
-        if: env.WHITESOURCE_SCAN=='true'
-        env:
-          unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"
-          unified_agent_sha_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar.sha256"
-          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-          TARGET_DIR: "service/application/target/lib"
-          WS_EXCLUDES: "local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
-        run: |
-          echo "Whitesource- Downloading and verifying latest Agent"
-
-          curl -LJOs ${{ env.unified_agent_url }}
-          sha_from_jar=$(sha256sum  wss-unified-agent.jar | awk '{print $1}')
-          curl -LJOs ${{ env.unified_agent_sha_url }}
-          sha_from_file=$(cat wss-unified-agent.jar.sha256 | awk '{print $1}')
-          if [[ "$sha_from_file" == "$sha_from_jar" ]]; then
-              echo "Integrity of the wss-unified-agent.jar file verified .."
-          else
-              echo "Integrity check of wss-unified-agent.jar file failed .."
-              echo "sha_from_jar: $sha_from_jar"
-              echo "sha_from_file: $sha_from_file"
-              exit 1
-          fi
-
-          echo "Whitesource- Copying Maven Dependencies"
-          mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
-
-          echo "Whitesource- Running scan"
-          java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel Info
-
-      - name: Deploy Artifacts
-        if: env.GITHUB_PACKAGES_DEPLOY=='true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mvn deploy $SKIP_FLAGS_ALL_TESTS -Dmaven.install.skip=true --file service/pom.xml
+#      - name: Static Code Analysis
+#        run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml
+#      - name: Unit Tests
+#        run: mvn -B test $SKIP_FLAGS_NON_UNIT_TESTS --file service/pom.xml
+#      - name: Generate Artifacts
+#        run: |
+#          mvn install $SKIP_FLAGS_ALL_TESTS --file service/pom.xml
+#      - name: Sonar Scan
+#        env:
+#          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+#          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+#        run: |
+#          mvn -B $SKIP_FLAGS_ALL_TESTS \
+#            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_runtime-agent \
+#            --file service/pom.xml
+#      - name: WhiteSource Scan
+#        if: env.WHITESOURCE_SCAN=='true'
+#        env:
+#          unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"
+#          unified_agent_sha_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar.sha256"
+#          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+#          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+#          TARGET_DIR: "service/application/target/lib"
+#          WS_EXCLUDES: "local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
+#        run: |
+#          echo "Whitesource- Downloading and verifying latest Agent"
+#
+#          curl -LJOs ${{ env.unified_agent_url }}
+#          sha_from_jar=$(sha256sum  wss-unified-agent.jar | awk '{print $1}')
+#          curl -LJOs ${{ env.unified_agent_sha_url }}
+#          sha_from_file=$(cat wss-unified-agent.jar.sha256 | awk '{print $1}')
+#          if [[ "$sha_from_file" == "$sha_from_jar" ]]; then
+#              echo "Integrity of the wss-unified-agent.jar file verified .."
+#          else
+#              echo "Integrity check of wss-unified-agent.jar file failed .."
+#              echo "sha_from_jar: $sha_from_jar"
+#              echo "sha_from_file: $sha_from_file"
+#              exit 1
+#          fi
+#
+#          echo "Whitesource- Copying Maven Dependencies"
+#          mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
+#
+#          echo "Whitesource- Running scan"
+#          java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel Info
+#
+#      - name: Deploy Artifacts
+#        if: env.GITHUB_PACKAGES_DEPLOY=='true'
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          mvn deploy $SKIP_FLAGS_ALL_TESTS -Dmaven.install.skip=true --file service/pom.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,15 +40,15 @@ jobs:
           echo "$GITHUB_EVENT_NAME"
           echo "$GITHUB_REF_NAME"
           if [[ $GITHUB_EVENT_NAME != "pull_request" && $GITHUB_REF_NAME="add_whitesource" ]]; then
-            export MAN_BRANCH_BUILD=true
+            export MAIN_BRANCH_BUILD=true
           else
-            export MAN_BRANCH_BUILD=false
+            export MAIN_BRANCH_BUILD=false
           fi
-          echo "$MAN_BRANCH_BUILD"
-          echo "MAN_BRANCH_BUILD=$MAN_BRANCH_BUILD" >> $GITHUB_ENV
-      - run: echo "$MAN_BRANCH_BUILD"
+          echo "$MAIN_BRANCH_BUILD"
+          echo "MAIN_BRANCH_BUILD=$MAIN_BRANCH_BUILD" >> $GITHUB_ENV
+      - run: echo "$MAIN_BRANCH_BUILD"
       - name: test
-        if: env.MAN_BRANCH_BUILD
+        if: env.MAIN_BRANCH_BUILD
         run: "echo yes I am main branch"
 #      - name: Static Code Analysis
 #        run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
           echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
           echo "$GITHUB_REF_NAME"
           echo "$GITHUB_EVENT_NAME"
-          if [[ $GITHUB_EVENT_NAME != "pull_request" && $GITHUB_REF_NAME == "main" ]]; then
+          if [[ $GITHUB_REF_NAME == "main" ]]; then
             export WHITESOURCE_SCAN=true
             export GITHUB_PACKAGES_DEPLOY=true
           else

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,8 @@ jobs:
           export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
           echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
           echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-          if [[ $GITHUB_REF_NAME=="main" ]]; then
+          echo "$GITHUB_REF_NAME"
+          if [[ $GITHUB_EVENT_NAME != "pull_request" && $GITHUB_REF_NAME=="main" ]]; then
             export WHITESOURCE_SCAN=true
             export GITHUB_PACKAGES_DEPLOY=true
           else

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,7 +76,7 @@ jobs:
           WHITESOURCE_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WHITESOURCE_PROJECT_TOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
           TARGET_DIR: "service/application/target"
-        run: java -jar wss-unified-agent.jar -apiKey ${{ env.WHITESOURCE_API_KEY }}   -projectToken ${{ env.WHITESOURCE_PROJECT_TOKEN }} -d  ${{ env.TARGET_DIR }}
+        run: java -jar wss-unified-agent.jar -apiKey ${{ env.WHITESOURCE_API_KEY }}   -projectToken ${{ env.WHITESOURCE_PROJECT_TOKEN }} -d  ${{ env.TARGET_DIR }} -logLevel Trace
 
 #      - name: Deploy Artifacts
 #        if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,55 +49,55 @@ jobs:
           echo "$WHITESOURCE_SCAN"
           echo "WHITESOURCE_SCAN=$WHITESOURCE_SCAN" >> $GITHUB_ENV
           echo "GITHUB_PACKAGES_DEPLOY=$GITHUB_PACKAGES_DEPLOY" >> $GITHUB_ENV
-#      - name: Static Code Analysis
-#        run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml
-#      - name: Unit Tests
-#        run: mvn -B test $SKIP_FLAGS_NON_UNIT_TESTS --file service/pom.xml
-#      - name: Generate Artifacts
-#        run: |
-#          mvn install $SKIP_FLAGS_ALL_TESTS --file service/pom.xml
-#      - name: Sonar Scan
-#        env:
-#          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-#          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-#        run: |
-#          mvn -B $SKIP_FLAGS_ALL_TESTS \
-#            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_runtime-agent \
-#            --file service/pom.xml
-#      - name: WhiteSource Scan
-#        if: env.WHITESOURCE_SCAN=='true'
-#        env:
-#          unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"
-#          unified_agent_sha_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar.sha256"
-#          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-#          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-#          TARGET_DIR: "service/application/target/lib"
-#          WS_EXCLUDES: "local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
-#        run: |
-#          echo "Whitesource- Downloading and verifying latest Agent"
-#
-#          curl -LJOs ${{ env.unified_agent_url }}
-#          sha_from_jar=$(sha256sum  wss-unified-agent.jar | awk '{print $1}')
-#          curl -LJOs ${{ env.unified_agent_sha_url }}
-#          sha_from_file=$(cat wss-unified-agent.jar.sha256 | awk '{print $1}')
-#          if [[ "$sha_from_file" == "$sha_from_jar" ]]; then
-#              echo "Integrity of the wss-unified-agent.jar file verified .."
-#          else
-#              echo "Integrity check of wss-unified-agent.jar file failed .."
-#              echo "sha_from_jar: $sha_from_jar"
-#              echo "sha_from_file: $sha_from_file"
-#              exit 1
-#          fi
-#
-#          echo "Whitesource- Copying Maven Dependencies"
-#          mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
-#
-#          echo "Whitesource- Running scan"
-#          java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel Info
-#
-#      - name: Deploy Artifacts
-#        if: env.GITHUB_PACKAGES_DEPLOY=='true'
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          mvn deploy $SKIP_FLAGS_ALL_TESTS -Dmaven.install.skip=true --file service/pom.xml
+      - name: Static Code Analysis
+        run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml
+      - name: Unit Tests
+        run: mvn -B test $SKIP_FLAGS_NON_UNIT_TESTS --file service/pom.xml
+      - name: Generate Artifacts
+        run: |
+          mvn install $SKIP_FLAGS_ALL_TESTS --file service/pom.xml
+      - name: Sonar Scan
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        run: |
+          mvn -B $SKIP_FLAGS_ALL_TESTS \
+            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_runtime-agent \
+            --file service/pom.xml
+      - name: WhiteSource Scan
+        if: env.WHITESOURCE_SCAN=='true'
+        env:
+          unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"
+          unified_agent_sha_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar.sha256"
+          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+          TARGET_DIR: "service/application/target/lib"
+          WS_EXCLUDES: "local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
+        run: |
+          echo "Whitesource- Downloading and verifying latest Agent"
+
+          curl -LJOs ${{ env.unified_agent_url }}
+          sha_from_jar=$(sha256sum  wss-unified-agent.jar | awk '{print $1}')
+          curl -LJOs ${{ env.unified_agent_sha_url }}
+          sha_from_file=$(cat wss-unified-agent.jar.sha256 | awk '{print $1}')
+          if [[ "$sha_from_file" == "$sha_from_jar" ]]; then
+              echo "Integrity of the wss-unified-agent.jar file verified .."
+          else
+              echo "Integrity check of wss-unified-agent.jar file failed .."
+              echo "sha_from_jar: $sha_from_jar"
+              echo "sha_from_file: $sha_from_file"
+              exit 1
+          fi
+
+          echo "Whitesource- Copying Maven Dependencies"
+          mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
+
+          echo "Whitesource- Running scan"
+          java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel Info
+
+      - name: Deploy Artifacts
+        if: env.GITHUB_PACKAGES_DEPLOY=='true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mvn deploy $SKIP_FLAGS_ALL_TESTS -Dmaven.install.skip=true --file service/pom.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,10 @@ jobs:
           fi
           echo "$MAN_BRANCH_BUILD"
           echo "MAN_BRANCH_BUILD=$MAN_BRANCH_BUILD" >> $GITHUB_ENV
-       - run: echo "$MAN_BRANCH_BUILD"
+      - run: echo "$MAN_BRANCH_BUILD"
+      - name: test
+        if: env.MAN_BRANCH_BUILD=='true'
+        run: "echo yes I am main branch"
 #      - name: Static Code Analysis
 #        run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml
 #      - name: Unit Tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,35 +62,36 @@ jobs:
           mvn -B $SKIP_FLAGS_ALL_TESTS \
             org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_runtime-agent \
             --file service/pom.xml
-      - name: Whitesource:: Download latest Agent
+      - name: Whitesource Scan
         if: env.WHITESOURCE_SCAN=='true'
         env:
           unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"
           unified_agent_sha_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar.sha256"
-        run: |
-          curl -LJOs ${{ env.unified_agent_url }}
-          sha_from_jar=$(sha256sum  wss-unified-agent.jar | awk '{print $1}')
-          curl -LJOs ${{ env.unified_agent_sha_url }}
-          sha_from_file=$(cat wss-unified-agent.jar.sha256 | awk '{print $1}')
-          echo "sha_from_jar: $sha_from_jar"
-          echo "sha_from_file: $sha_from_file"
-          if [[ "$sha_from_file" == "$sha_from_jar" ]]; then
-              echo "Integrity of the wss-unified-agent.jar file verified .."
-          else
-              echo "Integrity check of wss-unified-agent.jar file failed .."
-              exit 1
-          fi
-      - name: Whitesource:: Copy Maven Dependencies
-        if: env.WHITESOURCE_SCAN=='true'
-        run: mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
-      - name: Whitesource:: Scan
-        if: env.WHITESOURCE_SCAN=='true'
-        env:
           WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
           TARGET_DIR: "service/application/target/lib"
           WS_EXCLUDES: "local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
-        run: java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel Info
+        run: |
+          echo "Whitesource- Downloading and verifying latest Agent"
+
+          curl -LJOs ${{ env.unified_agent_url }}
+          sha_from_jar=$(sha256sum  wss-unified-agent.jar | awk '{print $1}')
+          curl -LJOs ${{ env.unified_agent_sha_url }}
+          sha_from_file=$(cat wss-unified-agent.jar.sha256 | awk '{print $1}')
+          if [[ "$sha_from_file" == "$sha_from_jar" ]]; then
+              echo "Integrity of the wss-unified-agent.jar file verified .."
+          else
+              echo "Integrity check of wss-unified-agent.jar file failed .."
+              echo "sha_from_jar: $sha_from_jar"
+              echo "sha_from_file: $sha_from_file"
+              exit 1
+          fi
+
+          echo "Whitesource- Copying Maven Dependencies"
+          mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
+
+          echo "Whitesource- Running scan"
+          java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel Info
 
 #      - name: Deploy Artifacts
 #        if: env.GITHUB_PACKAGES_DEPLOY=='true'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,7 +82,7 @@ jobs:
         run: java -jar wss-unified-agent.jar \
               -apiKey ${{ env.WHITESOURCE_API_KEY }}   -projectToken ${{ env.WHITESOURCE_PROJECT_TOKEN }} \
               -d  ${{ env.TARGET_DIR }} \
-              -excludes $${{ env.WHITESOURCE_EXCLUDES }} -logLevel info
+              -excludes ${{ env.WHITESOURCE_EXCLUDES }} -logLevel info
 
 #      - name: Deploy Artifacts
 #        if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,7 +88,7 @@ jobs:
           fi
 
           echo "Whitesource- Copying Maven Dependencies"
-          mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
+          mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib -Dsilent=true --file service/pom.xml
 
           echo "Whitesource- Running scan"
           java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel Info

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
           mvn -B $SKIP_FLAGS_ALL_TESTS \
             org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_runtime-agent \
             --file service/pom.xml
-      - name: Whitesource Scan
+      - name: WhiteSource Scan
         if: env.WHITESOURCE_SCAN=='true'
         env:
           unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,10 +2,10 @@ name: Build
 on:
   push:
     branches:
-      - add_whitesource
+      - main
     paths-ignore:
       - '.gitignore'
-#      - '.github/**'
+      - '.github/**'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened]
@@ -88,14 +88,14 @@ jobs:
           fi
 
           echo "Whitesource- Copying Maven Dependencies"
-          mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib -Dsilent=true --file service/pom.xml
+          mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
 
           echo "Whitesource- Running scan"
           java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel Info
 
-#      - name: Deploy Artifacts
-#        if: env.GITHUB_PACKAGES_DEPLOY=='true'
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          mvn deploy $SKIP_FLAGS_ALL_TESTS -Dmaven.install.skip=true --file service/pom.xml
+      - name: Deploy Artifacts
+        if: env.GITHUB_PACKAGES_DEPLOY=='true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mvn deploy $SKIP_FLAGS_ALL_TESTS -Dmaven.install.skip=true --file service/pom.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
           echo "MAN_BRANCH_BUILD=$MAN_BRANCH_BUILD" >> $GITHUB_ENV
       - run: echo "$MAN_BRANCH_BUILD"
       - name: test
-        if: env.MAN_BRANCH_BUILD=='true'
+        if: env.MAN_BRANCH_BUILD
         run: "echo yes I am main branch"
 #      - name: Static Code Analysis
 #        run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,7 +78,7 @@ jobs:
           WHITESOURCE_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WHITESOURCE_PROJECT_TOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
           TARGET_DIR: "service/application/target/lib"
-          WHITESOURCE_EXCLUDES: "local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
+          WHITESOURCE_EXCLUDES: "'local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar'"
         run: java -jar wss-unified-agent.jar \
               -apiKey ${{ env.WHITESOURCE_API_KEY }}   -projectToken ${{ env.WHITESOURCE_PROJECT_TOKEN }} \
               -d  ${{ env.TARGET_DIR }} \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
       - add_whitesource
     paths-ignore:
       - '.gitignore'
-      - '.github/**'
+#      - '.github/**'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,30 +39,29 @@ jobs:
           echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
           if [[ $GITHUB_EVENT_NAME != "pull_request" && $GITHUB_REF_NAME="add_whitesource" ]]; then
             export WHITESOURCE_SCAN=true
+            export GITHUB_PACKAGES_DEPLOY=true
           else
             export WHITESOURCE_SCAN=false
+            export GITHUB_PACKAGES_DEPLOY=false
           fi
           echo "$WHITESOURCE_SCAN"
           echo "WHITESOURCE_SCAN=$WHITESOURCE_SCAN" >> $GITHUB_ENV
-      - run: echo "$MAIN_BRANCH_BUILD"
-      - name: test
-        if: env.MAIN_BRANCH_BUILD=='true'
-        run: "echo yes I am main branch"
-#      - name: Static Code Analysis
-#        run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml
-#      - name: Unit Tests
-#        run: mvn -B test $SKIP_FLAGS_NON_UNIT_TESTS --file service/pom.xml
-#      - name: Generate Artifacts
-#        run: |
-#          mvn install $SKIP_FLAGS_ALL_TESTS --file service/pom.xml
-#      - name: Sonar Scan
-#        env:
-#          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-#          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-#        run: |
-#          mvn -B $SKIP_FLAGS_ALL_TESTS \
-#            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_runtime-agent \
-#            --file service/pom.xml
+          echo "GITHUB_PACKAGES_DEPLOY=$GITHUB_PACKAGES_DEPLOY" >> $GITHUB_ENV
+      - name: Static Code Analysis
+        run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml
+      - name: Unit Tests
+        run: mvn -B test $SKIP_FLAGS_NON_UNIT_TESTS --file service/pom.xml
+      - name: Generate Artifacts
+        run: |
+          mvn install $SKIP_FLAGS_ALL_TESTS --file service/pom.xml
+      - name: Sonar Scan
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        run: |
+          mvn -B $SKIP_FLAGS_ALL_TESTS \
+            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_runtime-agent \
+            --file service/pom.xml
       - name: Download latest Mend/Whitesource Agent
         if: env.WHITESOURCE_SCAN=='true'
         env:
@@ -94,7 +93,7 @@ jobs:
         run: java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel Info
 
 #      - name: Deploy Artifacts
-#        if: ${{ github.ref == 'refs/heads/main' }}
+#        if: env.GITHUB_PACKAGES_DEPLOY=='true'
 #        env:
 #          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #        run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,9 +58,9 @@ jobs:
           unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"
           unified_agent_sha_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar.sha256"
         run: |
-          curl -LJO ${{ env.unified_agent_url }}
+          curl -LJOs ${{ env.unified_agent_url }}
           sha_from_jar=$(sha256sum  wss-unified-agent.jar | awk '{print $1}')
-          curl -LJO ${{ env.unified_agent_sha_url }}
+          curl -LJOs ${{ env.unified_agent_sha_url }}
           sha_from_file=$(cat wss-unified-agent.jar.sha256 | awk '{print $1}')
           echo "sha_from_jar: $sha_from_jar"
           echo "sha_from_file: $sha_from_file"
@@ -72,14 +72,14 @@ jobs:
           fi
       - name: Copy Maven Dependencies
         run: mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
-      - name: Perform Whitesource Scan
+      - name: Whitesource Scan
         if: ${{ github.ref == 'refs/heads/add_whitesource' }}
         env:
           WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
           TARGET_DIR: "service/application/target/lib"
           WS_EXCLUDES: "local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
-        run: java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel info
+        run: java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel Info
 
 #      - name: Deploy Artifacts
 #        if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
           export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
           echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
           echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-          if [[ $GITHUB_EVENT_NAME != "pull_request" && $GITHUB_REF_NAME="add_whitesource" ]]; then
+          if [[ $GITHUB_EVENT_NAME != "pull_request" && $GITHUB_REF_NAME="main" ]]; then
             export WHITESOURCE_SCAN=true
             export GITHUB_PACKAGES_DEPLOY=true
           else

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,14 +75,11 @@ jobs:
       - name: Perform Whitesource Scan
         if: ${{ github.ref == 'refs/heads/add_whitesource' }}
         env:
-          WHITESOURCE_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
-          WHITESOURCE_PROJECT_TOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
           TARGET_DIR: "service/application/target/lib"
-          WHITESOURCE_EXCLUDES: "'local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar'"
-        run: java -jar wss-unified-agent.jar \
-              -apiKey ${{ env.WHITESOURCE_API_KEY }}   -projectToken ${{ env.WHITESOURCE_PROJECT_TOKEN }} \
-              -d  ${{ env.TARGET_DIR }} \
-              -excludes ${{ env.WHITESOURCE_EXCLUDES }} -logLevel info
+          WS_EXCLUDES: "local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
+        run: java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel info
 
 #      - name: Deploy Artifacts
 #        if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,13 +37,22 @@ jobs:
           export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
           echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
           echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
+          if [ $GITHUB_EVENT_NAME != "pull_request" && $GITHUB_REF_NAME="add_whitesource" ]
+          then
+            export MAN_BRANCH_BUILD=true
+          else
+            export MAN_BRANCH_BUILD=false
+          fi
+          echo "$MAN_BRANCH_BUILD"
+          echo "MAN_BRANCH_BUILD=$MAN_BRANCH_BUILD" >> $GITHUB_ENV
+       - run: echo "$MAN_BRANCH_BUILD"
 #      - name: Static Code Analysis
 #        run: mvn -B compile -Pmaas-static-code-analysis --file service/pom.xml
 #      - name: Unit Tests
 #        run: mvn -B test $SKIP_FLAGS_NON_UNIT_TESTS --file service/pom.xml
-      - name: Generate Artifacts
-        run: |
-          mvn install $SKIP_FLAGS_ALL_TESTS --file service/pom.xml
+#      - name: Generate Artifacts
+#        run: |
+#          mvn install $SKIP_FLAGS_ALL_TESTS --file service/pom.xml
 #      - name: Sonar Scan
 #        env:
 #          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -52,34 +61,34 @@ jobs:
 #          mvn -B $SKIP_FLAGS_ALL_TESTS \
 #            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_runtime-agent \
 #            --file service/pom.xml
-      - name: Download latest Mend/Whitesource Agent
-        if: ${{ github.ref == 'refs/heads/add_whitesource' }}
-        env:
-          unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"
-          unified_agent_sha_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar.sha256"
-        run: |
-          curl -LJOs ${{ env.unified_agent_url }}
-          sha_from_jar=$(sha256sum  wss-unified-agent.jar | awk '{print $1}')
-          curl -LJOs ${{ env.unified_agent_sha_url }}
-          sha_from_file=$(cat wss-unified-agent.jar.sha256 | awk '{print $1}')
-          echo "sha_from_jar: $sha_from_jar"
-          echo "sha_from_file: $sha_from_file"
-          if [[ "$sha_from_file" == "$sha_from_jar" ]]; then
-              echo "Integrity of the wss-unified-agent.jar file verified .."
-          else
-              echo "Integrity check of wss-unified-agent.jar file failed .."
-              exit 1
-          fi
-      - name: Copy Maven Dependencies
-        run: mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
-      - name: Whitesource Scan
+#      - name: Download latest Mend/Whitesource Agent
 #        if: ${{ github.ref == 'refs/heads/add_whitesource' }}
-        env:
-          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-          TARGET_DIR: "service/application/target/lib"
-          WS_EXCLUDES: "local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
-        run: java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel Info
+#        env:
+#          unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"
+#          unified_agent_sha_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar.sha256"
+#        run: |
+#          curl -LJOs ${{ env.unified_agent_url }}
+#          sha_from_jar=$(sha256sum  wss-unified-agent.jar | awk '{print $1}')
+#          curl -LJOs ${{ env.unified_agent_sha_url }}
+#          sha_from_file=$(cat wss-unified-agent.jar.sha256 | awk '{print $1}')
+#          echo "sha_from_jar: $sha_from_jar"
+#          echo "sha_from_file: $sha_from_file"
+#          if [[ "$sha_from_file" == "$sha_from_jar" ]]; then
+#              echo "Integrity of the wss-unified-agent.jar file verified .."
+#          else
+#              echo "Integrity check of wss-unified-agent.jar file failed .."
+#              exit 1
+#          fi
+#      - name: Copy Maven Dependencies
+#        run: mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
+#      - name: Whitesource Scan
+##        if: ${{ github.ref == 'refs/heads/add_whitesource' }}
+#        env:
+#          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+#          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+#          TARGET_DIR: "service/application/target/lib"
+#          WS_EXCLUDES: "local-storage-plugin*.jar,plugin*.jar,kafka-plugin*.jar,confluent-schema-registry-plugin*.jar"
+#        run: java -jar wss-unified-agent.jar -d  ${{ env.TARGET_DIR }}  -logLevel Info
 
 #      - name: Deploy Artifacts
 #        if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Copy Maven Dependencies
         run: mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
       - name: Whitesource Scan
-        if: ${{ github.ref == 'refs/heads/add_whitesource' }}
+#        if: ${{ github.ref == 'refs/heads/add_whitesource' }}
         env:
           WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
           mvn -B $SKIP_FLAGS_ALL_TESTS \
             org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_runtime-agent \
             --file service/pom.xml
-      - name: Download latest Mend/Whitesource Agent
+      - name: Whitesource:: Download latest Agent
         if: env.WHITESOURCE_SCAN=='true'
         env:
           unified_agent_url: "https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar"
@@ -80,10 +80,10 @@ jobs:
               echo "Integrity check of wss-unified-agent.jar file failed .."
               exit 1
           fi
-      - name: Copy Maven Dependencies
+      - name: Whitesource:: Copy Maven Dependencies
         if: env.WHITESOURCE_SCAN=='true'
         run: mvn dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=target/lib --file service/pom.xml
-      - name: Whitesource Scan
+      - name: Whitesource:: Scan
         if: env.WHITESOURCE_SCAN=='true'
         env:
           WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,8 +75,8 @@ jobs:
         env:
           WHITESOURCE_API_KEY: ${{ secrets.WHITESOURCE_API_KEY }}
           WHITESOURCE_PROJECT_TOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-          TARGET_DIR: "service/kafka-plugin/target"
-        run: java -jar wss-unified-agent.jar -apiKey ${{ env.WHITESOURCE_API_KEY }}   -projectToken ${{ env.WHITESOURCE_PROJECT_TOKEN }} -d  ${{ env.TARGET_DIR }} -logLevel info
+          TARGET_DIR: "service/application/target"
+        run: java -jar wss-unified-agent.jar -apiKey ${{ env.WHITESOURCE_API_KEY }}   -projectToken ${{ env.WHITESOURCE_PROJECT_TOKEN }} -d  ${{ env.TARGET_DIR }}
 
 #      - name: Deploy Artifacts
 #        if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
### What is the purpose of this change?
Adding Whitesource Scan to Build Workflow

### How was this change implemented?
Whitesource scan step added to the build workflow, which does:
- Download latest Mend/Whitesource Agent
- Copy Maven Dependencies which copies all the dependencies to target/lib folder
- Whitesource Scan to run the `wss-unified-agent.jar` scan against `target/lib` folder
- - Solace plugins have been exculded using `WS_EXCLUDES`
- - API key and Project token has been added as repository secrets and passed as env variables.
- 
### How was this change tested?
- https://github.com/SolaceLabs/event-management-agent/actions/runs/4939677815/jobs/8830635052
- on Whitesource: https://saas.whitesourcesoftware.com/Wss/WSS.html#!project;id=9570292;orgToken=0da69ef9-91b1-40a5-933f-2c4b29014240