### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.BUILD_SVC_PAT }}
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
@@ -30,7 +29,7 @@ jobs:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
-          release_version_exists=$(jq -r --arg RELEASE_VERIOSN v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERIOSN))'  releases.json)
+          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
           if [[ ! -z "$release_version_exists" ]]; then
                 echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
                 exit 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: "Default version to use when preparing a release."
+        required: true
+        default: "X.Y.Z"
+      developmentVersion:
+        description: "Default version to use for new local working copy."
+        required: true
+        default: "X.Y.Z-SNAPSHOT"
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.BUILD_SVC_PAT }}
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Pre-Release Check - Version
+        env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
+          release_version_exists=$(jq -r --arg RELEASE_VERIOSN v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERIOSN))'  releases.json)
+          if [[ ! -z "$release_version_exists" ]]; then
+                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
+                exit 1
+          else
+                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
+          fi


### PR DESCRIPTION
### What is the purpose of this change?
Adding release workflow.
The workflow has two inputs:
- releaseVersion: version that we want to deploy in x.y.z format
- developmentVersion: next development version (in x.y.z-snapshot format)

### How was this change implemented?
Added a workflow file: `.github/workflows/release.yaml` which can be triggered manually.
- Currently it only contians a pre-check to make sure that the inoput version has not been previously released.
The workflow uses github api to query previous released.

Test Runs (in a test repo) for a previously released verion
![image](https://github.com/SolaceLabs/event-management-agent/assets/59615308/c9c2de11-9579-48b3-9185-cb8ff2791a92)
