### PR TITLE
DATAGO-55547: Fail EMA build workflow in case of error

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -290,7 +290,7 @@
                             <rulesets>
                                 <ruleset>../resources/pmd/pmd-rules.xml</ruleset>
                             </rulesets>
-                            <failOnViolation>false</failOnViolation>
+                            <failOnViolation>true</failOnViolation>
                             <includeTests>true</includeTests>
                         </configuration>
                         <executions>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -341,7 +341,7 @@
                             <rulesets>
                                 <ruleset>resources/pmd/pmd-rules.xml</ruleset>
                             </rulesets>
-                            <failOnViolation>false</failOnViolation>
+                            <failOnViolation>true</failOnViolation>
                             <includeTests>true</includeTests>
                         </configuration>
                         <executions>


### PR DESCRIPTION
Updated `failOnViolation` in pom files to true so that build workflow fails in the case of errors.