### PR TITLE
Fix spring-boot-autoconfigure-2.7.11 vulnerability

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -37,6 +37,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <version>2.7.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>

--- a/service/local-storage-plugin/pom.xml
+++ b/service/local-storage-plugin/pom.xml
@@ -17,7 +17,8 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <jacksondatabind.version>2.13.4.2</jacksondatabind.version>
         <junit.version>4.13.2</junit.version>
-        <spring-boot-starter-test.version>2.7.6</spring-boot-starter-test.version>
+        <spring-boot-starter.version>2.7.12</spring-boot-starter.version>
+        <spring-boot-starter-test.version>2.7.12</spring-boot-starter-test.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <jupiter.version>5.3.1</jupiter.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
@@ -66,6 +67,17 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <version>${spring-boot-starter.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/service/plugin/pom.xml
+++ b/service/plugin/pom.xml
@@ -33,6 +33,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <version>2.7.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
### What is the purpose of this change?

To fix the white-source spring-boot-autoconfigure-2.7.11 vulnerability

### How was this change implemented?

By updating the spring-boot-autoconfigure to 2.7.12

### How was this change tested?

Manually by building the EMA then running Kafka and Solace scans

### Is there anything the reviewers should focus on/be aware of?

N/A
