### PR TITLE
Fix mysql-connector-java dependency vulnerability

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.29</version>
+            <version>8.0.32</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
### What is the purpose of this change?

To fix the white-source protobuf-java vulnerability

### How was this change implemented?

By updating the mysql-connector-java to 8.0.32

### How was this change tested?

Manually by building the EMA then running Kafka and Solace scans

### Is there anything the reviewers should focus on/be aware of?

N/A
