### PR TITLE
Authenicate users for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
            GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members > release_team.json
-          user_is_in_release_team = $(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
+          user_is_in_release_team=$(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
           if [[ -z "$user_is_in_release_team" ]]; then
                 echo "Current user (${{ github.actor }}) is in ema-release-team ✅."
           else

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,12 +19,12 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: 11
-#          distribution: 'temurin'
-#          cache: 'maven'
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: 'maven'
       - name: Pre-Release Check - Authenticate User
         env:
            GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
@@ -37,56 +37,56 @@ jobs:
                 echo "❌ Current user (${{ github.actor }}) is not authorized for release."
                 exit 1
           fi
-#      - name: Pre-Release Check - Version
-#        env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
-#          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
-#          if [[ ! -z "$release_version_exists" ]]; then
-#                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
-#                exit 1
-#          else
-#                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
-#          fi
-#      - name: Set up Python 3.8
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: 3.8
-#          cache: 'pip'
-#      - name: Pre-Release Check - Whitesource vulnurabilities
-#        env:
-#          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-#          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-#          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-#        run: |
-#          pip install --quiet --upgrade pip
-#          export VIRTUAL_ENV=./venv
-#          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-#          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
-#      - name: Set Release Configs
-#        run: |
-#          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
-#          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
-#          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-#          git config user.email "actions@github.com"
-#          git config user.name "GitHub Actions"
-#      - name: Maven Release
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
-#      - name: Changelog
-#        uses: Bullrich/generate-release-changelog@master
-#        id: Changelog
-#        env:
-#          REPO: ${{ github.repository }}
-#      - name: Create GitHub Release
-#        uses: ncipollo/release-action@v1
-#        with:
-#          tag: "v${{ github.event.inputs.releaseVersion }}"
-#          artifacts: "**/application/target/*.jar"
-#          generateReleaseNotes: true
-#          makeLatest: true
-#          body: ${{ steps.Changelog.outputs.changelog }}
+      - name: Pre-Release Check - Version
+        env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
+          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
+          if [[ ! -z "$release_version_exists" ]]; then
+                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
+                exit 1
+          else
+                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
+          fi
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          cache: 'pip'
+      - name: Pre-Release Check - Whitesource vulnurabilities
+        env:
+          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: |
+          pip install --quiet --upgrade pip
+          export VIRTUAL_ENV=./venv
+          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
+      - name: Set Release Configs
+        run: |
+          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
+          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
+          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+      - name: Maven Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
+      - name: Changelog
+        uses: Bullrich/generate-release-changelog@master
+        id: Changelog
+        env:
+          REPO: ${{ github.repository }}
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "v${{ github.event.inputs.releaseVersion }}"
+          artifacts: "**/application/target/*.jar"
+          generateReleaseNotes: true
+          makeLatest: true
+          body: ${{ steps.Changelog.outputs.changelog }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,15 +29,14 @@ jobs:
         env:
            GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
-          gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members
-#          > release_team.json
-#          user_is_in_release_team = $(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
-#          if [[ -z "$user_is_in_release_team" ]]; then
-#                echo "Current user (${{ github.actor }}) is in ema-release-team ✅."
-#          else
-#                echo "❌ Current user (${{ github.actor }}) is not authorized for release."
-#                exit 1
-#          fi
+          gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members > release_team.json
+          user_is_in_release_team = $(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
+          if [[ -z "$user_is_in_release_team" ]]; then
+                echo "Current user (${{ github.actor }}) is in ema-release-team ✅."
+          else
+                echo "❌ Current user (${{ github.actor }}) is not authorized for release."
+                exit 1
+          fi
 #      - name: Pre-Release Check - Version
 #        env:
 #           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,56 +25,68 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           cache: 'maven'
-      - name: Pre-Release Check - Version
+      - name: Pre-Release Check - Authenticate User
         env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
-          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
-          if [[ ! -z "$release_version_exists" ]]; then
-                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
-                exit 1
+          gh api --method GET /orgs/SolaceLAbs/teams/ema-release-team/members > release_team.json
+          user_is_in_release_team = $(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
+          if [[ -z "$user_is_in_release_team" ]]; then
+                echo "Current user (${{ github.actor }}) is in ema-release-team ✅."
           else
-                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
+                echo "❌ Current user (${{ github.actor }}) is not authorized for release."
+                exit 1
           fi
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-          cache: 'pip'
-      - name: Pre-Release Check - Whitesource vulnurabilities
-        env:
-          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        run: |
-          pip install --quiet --upgrade pip
-          export VIRTUAL_ENV=./venv
-          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
-      - name: Set Release Configs
-        run: |
-          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
-          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
-          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-          git config user.email "actions@github.com"
-          git config user.name "GitHub Actions"
-      - name: Maven Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
-      - name: Changelog
-        uses: Bullrich/generate-release-changelog@master
-        id: Changelog
-        env:
-          REPO: ${{ github.repository }}
-      - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: "v${{ github.event.inputs.releaseVersion }}"
-          artifacts: "**/application/target/*.jar"
-          generateReleaseNotes: true
-          makeLatest: true
-          body: ${{ steps.Changelog.outputs.changelog }}
+#      - name: Pre-Release Check - Version
+#        env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
+#          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
+#          if [[ ! -z "$release_version_exists" ]]; then
+#                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
+#                exit 1
+#          else
+#                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
+#          fi
+#      - name: Set up Python 3.8
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: 3.8
+#          cache: 'pip'
+#      - name: Pre-Release Check - Whitesource vulnurabilities
+#        env:
+#          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+#          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+#          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+#        run: |
+#          pip install --quiet --upgrade pip
+#          export VIRTUAL_ENV=./venv
+#          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+#          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
+#      - name: Set Release Configs
+#        run: |
+#          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
+#          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
+#          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
+#          git config user.email "actions@github.com"
+#          git config user.name "GitHub Actions"
+#      - name: Maven Release
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
+#      - name: Changelog
+#        uses: Bullrich/generate-release-changelog@master
+#        id: Changelog
+#        env:
+#          REPO: ${{ github.repository }}
+#      - name: Create GitHub Release
+#        uses: ncipollo/release-action@v1
+#        with:
+#          tag: "v${{ github.event.inputs.releaseVersion }}"
+#          artifacts: "**/application/target/*.jar"
+#          generateReleaseNotes: true
+#          makeLatest: true
+#          body: ${{ steps.Changelog.outputs.changelog }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,21 +19,21 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: 'temurin'
-          cache: 'maven'
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: 11
+#          distribution: 'temurin'
+#          cache: 'maven'
       - name: Pre-Release Check - Authenticate User
         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
-          gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /orgs/SolaceLabs/teams/ema-release-team/members
-#          gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members
+#          gh api \
+#            -H "Accept: application/vnd.github+json" \
+#            -H "X-GitHub-Api-Version: 2022-11-28" \
+#            /orgs/SolaceLabs/teams/ema-release-team/members
+          gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members
 #          > release_team.json
 #          user_is_in_release_team = $(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
 #          if [[ -z "$user_is_in_release_team" ]]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,68 +26,56 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           cache: 'maven'
-#      - name: Pre-Release Check - Authenticate User
-#        env:
-#           GITHUB_TOKEN: ${{ secrets.RELEASE_TEAM_VALIDATION_TOKEN }}
-#        run: |
-#          gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members > release_team.json
-#          user_is_in_release_team=$(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
-#          if [[ ! -z "$user_is_in_release_team" ]]; then
-#                echo "Current user (${{ github.actor }}) is in ema-release-team ✅."
-#          else
-#                echo "❌ Current user (${{ github.actor }}) is not authorized for release."
-#                exit 1
-#          fi
-#      - name: Pre-Release Check - Version
-#        env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
-#          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
-#          if [[ ! -z "$release_version_exists" ]]; then
-#                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
-#                exit 1
-#          else
-#                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
-#          fi
-#      - name: Set up Python 3.8
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: 3.8
-#          cache: 'pip'
-#      - name: Pre-Release Check - Whitesource vulnurabilities
-#        env:
-#          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-#          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-#          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-#        run: |
-#          pip install --quiet --upgrade pip
-#          export VIRTUAL_ENV=./venv
-#          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-#          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
-#      - name: Set Release Configs
-#        run: |
-#          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
-#          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
-#          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-#          git config user.email "actions@github.com"
-#          git config user.name "GitHub Actions"
-#      - name: Maven Release
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
-#      - name: Changelog
-#        uses: Bullrich/generate-release-changelog@master
-#        id: Changelog
-#        env:
-#          REPO: ${{ github.repository }}
-#      - name: Create GitHub Release
-#        uses: ncipollo/release-action@v1
-#        with:
-#          tag: "v${{ github.event.inputs.releaseVersion }}"
-#          artifacts: "**/application/target/*.jar"
-#          generateReleaseNotes: true
-#          makeLatest: true
-#          body: ${{ steps.Changelog.outputs.changelog }}
+      - name: Pre-Release Check - Version
+        env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
+          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
+          if [[ ! -z "$release_version_exists" ]]; then
+                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
+                exit 1
+          else
+                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
+          fi
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          cache: 'pip'
+      - name: Pre-Release Check - Whitesource vulnurabilities
+        env:
+          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        run: |
+          pip install --quiet --upgrade pip
+          export VIRTUAL_ENV=./venv
+          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
+      - name: Set Release Configs
+        run: |
+          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
+          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
+          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+      - name: Maven Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
+      - name: Changelog
+        uses: Bullrich/generate-release-changelog@master
+        id: Changelog
+        env:
+          REPO: ${{ github.repository }}
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "v${{ github.event.inputs.releaseVersion }}"
+          artifacts: "**/application/target/*.jar"
+          generateReleaseNotes: true
+          makeLatest: true
+          body: ${{ steps.Changelog.outputs.changelog }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
         env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api --method GET /orgs/SolaceLAbs/teams/ema-release-team/members > release_team.json
+          gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members > release_team.json
           user_is_in_release_team = $(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
           if [[ -z "$user_is_in_release_team" ]]; then
                 echo "Current user (${{ github.actor }}) is in ema-release-team ✅."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ jobs:
            GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members > release_team.json
+          jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json
           user_is_in_release_team=$(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
           if [[ -z "$user_is_in_release_team" ]]; then
                 echo "Current user (${{ github.actor }}) is in ema-release-team ✅."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,9 +30,8 @@ jobs:
            GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members > release_team.json
-          jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json
           user_is_in_release_team=$(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
-          if [[ -z "$user_is_in_release_team" ]]; then
+          if [[ ! -z "$user_is_in_release_team" ]]; then
                 echo "Current user (${{ github.actor }}) is in ema-release-team ✅."
           else
                 echo "❌ Current user (${{ github.actor }}) is not authorized for release."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,10 +29,6 @@ jobs:
         env:
            GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
-#          gh api \
-#            -H "Accept: application/vnd.github+json" \
-#            -H "X-GitHub-Api-Version: 2022-11-28" \
-#            /orgs/SolaceLabs/teams/ema-release-team/members
           gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members
 #          > release_team.json
 #          user_is_in_release_team = $(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
           cache: 'maven'
       - name: Pre-Release Check - Authenticate User
         env:
-           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+           GITHUB_TOKEN: ${{ secrets.RELEASE_TEAM_VALIDATION_TOKEN }}
         run: |
           gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members > release_team.json
           user_is_in_release_team=$(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
@@ -37,56 +37,56 @@ jobs:
                 echo "❌ Current user (${{ github.actor }}) is not authorized for release."
                 exit 1
           fi
-      - name: Pre-Release Check - Version
-        env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
-          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
-          if [[ ! -z "$release_version_exists" ]]; then
-                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
-                exit 1
-          else
-                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
-          fi
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-          cache: 'pip'
-      - name: Pre-Release Check - Whitesource vulnurabilities
-        env:
-          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        run: |
-          pip install --quiet --upgrade pip
-          export VIRTUAL_ENV=./venv
-          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
-      - name: Set Release Configs
-        run: |
-          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
-          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
-          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-          git config user.email "actions@github.com"
-          git config user.name "GitHub Actions"
-      - name: Maven Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
-      - name: Changelog
-        uses: Bullrich/generate-release-changelog@master
-        id: Changelog
-        env:
-          REPO: ${{ github.repository }}
-      - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: "v${{ github.event.inputs.releaseVersion }}"
-          artifacts: "**/application/target/*.jar"
-          generateReleaseNotes: true
-          makeLatest: true
-          body: ${{ steps.Changelog.outputs.changelog }}
+#      - name: Pre-Release Check - Version
+#        env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
+#          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
+#          if [[ ! -z "$release_version_exists" ]]; then
+#                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
+#                exit 1
+#          else
+#                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
+#          fi
+#      - name: Set up Python 3.8
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: 3.8
+#          cache: 'pip'
+#      - name: Pre-Release Check - Whitesource vulnurabilities
+#        env:
+#          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+#          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+#          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+#        run: |
+#          pip install --quiet --upgrade pip
+#          export VIRTUAL_ENV=./venv
+#          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+#          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
+#      - name: Set Release Configs
+#        run: |
+#          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
+#          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
+#          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
+#          git config user.email "actions@github.com"
+#          git config user.name "GitHub Actions"
+#      - name: Maven Release
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
+#      - name: Changelog
+#        uses: Bullrich/generate-release-changelog@master
+#        id: Changelog
+#        env:
+#          REPO: ${{ github.repository }}
+#      - name: Create GitHub Release
+#        uses: ncipollo/release-action@v1
+#        with:
+#          tag: "v${{ github.event.inputs.releaseVersion }}"
+#          artifacts: "**/application/target/*.jar"
+#          generateReleaseNotes: true
+#          makeLatest: true
+#          body: ${{ steps.Changelog.outputs.changelog }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,11 @@ jobs:
         env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /orgs/SolaceLabs/teams/ema-release-team/members
+#          gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members
 #          > release_team.json
 #          user_is_in_release_team = $(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
 #          if [[ -z "$user_is_in_release_team" ]]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,14 +29,15 @@ jobs:
         env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members > release_team.json
-          user_is_in_release_team = $(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
-          if [[ -z "$user_is_in_release_team" ]]; then
-                echo "Current user (${{ github.actor }}) is in ema-release-team ✅."
-          else
-                echo "❌ Current user (${{ github.actor }}) is not authorized for release."
-                exit 1
-          fi
+          gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members
+#          > release_team.json
+#          user_is_in_release_team = $(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
+#          if [[ -z "$user_is_in_release_team" ]]; then
+#                echo "Current user (${{ github.actor }}) is in ema-release-team ✅."
+#          else
+#                echo "❌ Current user (${{ github.actor }}) is not authorized for release."
+#                exit 1
+#          fi
 #      - name: Pre-Release Check - Version
 #        env:
 #           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: prod
 
     steps:
       - uses: actions/checkout@v3
@@ -25,18 +26,18 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           cache: 'maven'
-      - name: Pre-Release Check - Authenticate User
-        env:
-           GITHUB_TOKEN: ${{ secrets.RELEASE_TEAM_VALIDATION_TOKEN }}
-        run: |
-          gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members > release_team.json
-          user_is_in_release_team=$(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
-          if [[ ! -z "$user_is_in_release_team" ]]; then
-                echo "Current user (${{ github.actor }}) is in ema-release-team ✅."
-          else
-                echo "❌ Current user (${{ github.actor }}) is not authorized for release."
-                exit 1
-          fi
+#      - name: Pre-Release Check - Authenticate User
+#        env:
+#           GITHUB_TOKEN: ${{ secrets.RELEASE_TEAM_VALIDATION_TOKEN }}
+#        run: |
+#          gh api --method GET /orgs/SolaceLabs/teams/ema-release-team/members > release_team.json
+#          user_is_in_release_team=$(jq -r --arg RELEASE_ACTOR ${{ github.actor }} '.[].login|select(.==$RELEASE_ACTOR)' release_team.json)
+#          if [[ ! -z "$user_is_in_release_team" ]]; then
+#                echo "Current user (${{ github.actor }}) is in ema-release-team ✅."
+#          else
+#                echo "❌ Current user (${{ github.actor }}) is not authorized for release."
+#                exit 1
+#          fi
 #      - name: Pre-Release Check - Version
 #        env:
 #           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What is the purpose of this change?
Make sure only memebers of `ema-release-team` can trigger the release workflow

### How was this change implemented?
- Added an environment called `prod` https://github.com/SolaceLabs/event-management-agent/settings/environments/1084306188/edit

where only ema-release-team can proceed with the release

- changed release workflow's environment to `prod`

![image](https://github.com/SolaceLabs/event-management-agent/assets/59615308/01a67be7-2c00-4cbc-99a0-2bd58c3e8808)

