### PR TITLE
DATAGO-55072: Change SonarQube Project Key

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
         run: |
           mvn -B $SKIP_FLAGS_ALL_TESTS \
-            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_runtime-agent \
+            org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=SolaceLabs_event-management-agent \
             --file service/pom.xml
       - name: WhiteSource Scan
         if: env.WHITESOURCE_SCAN=='true'


### PR DESCRIPTION
### What is the purpose of this change?
Changing SonarQube project key to `SolaceLabs_event-management-agent`
to match what we have in SonarQube

### How was this change implemented?
`sonar.projectKey` parameter updated in build workflow

