### PR TITLE
Using SSH keys for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,12 +55,13 @@ jobs:
           export VIRTUAL_ENV=./venv
           python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
           cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
-      - name: Prepate Maven Settings
+      - name: Prepare Maven Settings
         env:
           MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"
           MAVEN_REPO_SERVER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
           MAVEN_REPO_SERVER_PRIVATE_KEY: "~/.ssh/id_rsa"
           SSH_PRIVATE_KEY: "${{ secrets.COMMIT_KEY }}"
+        run: cd .github/workflows/release_scripts && ./setup-ssh.sh
       - name: Set Release Configs
         run: |
           export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
+
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
@@ -55,16 +55,19 @@ jobs:
           export VIRTUAL_ENV=./venv
           python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
           cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
+      - name: Prepate Maven Settings
+        env:
+          MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"
+          MAVEN_REPO_SERVER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
+          MAVEN_REPO_SERVER_PRIVATE_KEY: "~/.ssh/id_rsa"
+          SSH_PRIVATE_KEY: "${{ secrets.COMMIT_KEY }}"
       - name: Set Release Configs
         run: |
           export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
           echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
           echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-          git config user.email "actions@github.com"
-          git config user.name "GitHub Actions"
+
       - name: Maven Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
       - name: Changelog
         uses: Bullrich/generate-release-changelog@master

--- a/.github/workflows/release_scripts/settings-template.xml
+++ b/.github/workflows/release_scripts/settings-template.xml
@@ -1,0 +1,14 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <servers>
+        <server>
+            <id>github</id>
+            <username>${MAVEN_REPO_SERVER_USERNAME}</username>
+            <password>${MAVEN_REPO_SERVER_PASSWORD}</password>
+            <privateKey>${MAVEN_REPO_SERVER_PRIVATE_KEY}</privateKey>
+        </server>
+    </servers>
+
+</settings>

--- a/.github/workflows/release_scripts/setup-ssh.sh
+++ b/.github/workflows/release_scripts/setup-ssh.sh
@@ -1,0 +1,18 @@
+echo "preparing maven settings file"
+envsubst < settings-template.xml > "local-settings.xml"
+cp local-settings.xml ~/.m2/settings.xml
+
+echo "configure ssh key"
+mkdir -p ~/.ssh
+echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+chmod 600 ~/.ssh/id_rsa
+
+echo "Set StrictHostKeyChecking no"
+echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config
+
+echo "Whitelist  github.com in ~/.ssh/known_hosts"
+ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+
+echo "Configure Git User"
+git config user.email "actions@github.com"
+git config user.name "GitHub Actions"

--- a/.github/workflows/release_scripts/setup-ssh.sh
+++ b/.github/workflows/release_scripts/setup-ssh.sh
@@ -1,18 +1,18 @@
-echo "preparing maven settings file"
+echo "Preparing maven settings file"
 envsubst < settings-template.xml > "local-settings.xml"
 cp local-settings.xml ~/.m2/settings.xml
 
-echo "configure ssh key"
+echo "Configuring ssh key"
 mkdir -p ~/.ssh
 echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
 chmod 600 ~/.ssh/id_rsa
 
-echo "Set StrictHostKeyChecking no"
+echo "Setting StrictHostKeyChecking no"
 echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config
 
-echo "Whitelist  github.com in ~/.ssh/known_hosts"
+echo "Whitelisting  github.com in ~/.ssh/known_hosts"
 ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 
-echo "Configure Git User"
+echo "Configuring Git User"
 git config user.email "actions@github.com"
 git config user.name "GitHub Actions"

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -14,7 +14,6 @@
     <packaging>pom</packaging>
     <name>Solace Event Management Agent Maven Parent</name>
     <description>Solace Solace Event Management Agent Maven Parent</description>
-    <url>https://github.com/SolaceLabs/event-management-agent</url>
     <modules>
         <module>plugin</module>
         <module>rabbitmq-plugin</module>
@@ -42,8 +41,6 @@
         <org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
         <jacoco.line.percentage>0.8</jacoco.line.percentage>
         <camel.version>3.16.0</camel.version>
-        <git.repository>SolaceLabs/event-management-agent</git.repository>
-        <project.scm.id>github</project.scm.id>
     </properties>
 
     <dependencyManagement>
@@ -402,7 +399,9 @@
         </profile>
     </profiles>
     <scm>
-        <developerConnection>scm:git:https://github.com/${git.repository}.git</developerConnection>
+        <connection>scm:git:${project.scm.url}</connection>
+        <developerConnection>scm:git:${project.scm.url}</developerConnection>
+        <url>git@github.com:SolaceLabs/event-management-agent.git</url>
         <tag>HEAD</tag>
     </scm>
     <distributionManagement>


### PR DESCRIPTION
### What is the purpose of this change?
Using ssh key for release instead of token

### How was this change implemented?
- ssh key pair generated and added as deployment key/secret
- script added to configure the ssh key and update the maven settings file to use the generated key
- pom file added to use ssh for communicating with github
 