### PR TITLE
Push EMA main image with release tag to ECR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,7 +109,7 @@ jobs:
         run: |
           MANIFEST=$(aws ecr batch-get-image --repository-name ${{ github.event.repository.name }} --image-ids imageTag=main --query 'images[].imageManifest' --region ${{ secrets.EMA_AWS_DEFAULT_REGION }} --output text)
           echo $MANIFEST
-#          aws ecr put-image --repository-name ${{ github.event.repository.name }} --image-tag ${{ github.event.inputs.releaseVersion }} --image-manifest $MANIFEST --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+          aws ecr put-image --repository-name ${{ github.event.repository.name }} --image-tag ${{ github.event.inputs.releaseVersion }} --image-manifest \"\$MANIFEST\" --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}
 #          
 #          ECR_REPO="${{ steps.login-ecr.outputs.registry }}/"
 #          MAIN_IMAGE="$ECR_REPO:main"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,19 +55,19 @@ jobs:
           export VIRTUAL_ENV=./venv
           python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
           cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
-      - name: Pre-Release Check - Prisma vulnurabilities
-        env:
-          PRISMA_ROOT_API_URL: ${{ secrets.PRISMA_ROOT_API_URL }}
-          DOCKER_IMAGE_TO_CHECK: ${{ secrets.PRISMA_DOCKER_IMAGE_TO_CHECK }}
-          PRISMA_ACCESS_KEY: ${{ secrets.PRISMA_ACCESS_KEY }}
-          PRISMA_ACCESS_KEY_SECRET: ${{ secrets.PRISMA_ACCESS_KEY_SECRET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
-        run: |
-          export VIRTUAL_ENV=./venv
-          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-          cd ./.github/workflows/release_scripts/  && python3.8 prisma_vulnurability_checker.py
+#      - name: Pre-Release Check - Prisma vulnurabilities
+#        env:
+#          PRISMA_ROOT_API_URL: ${{ secrets.PRISMA_ROOT_API_URL }}
+#          DOCKER_IMAGE_TO_CHECK: ${{ secrets.PRISMA_DOCKER_IMAGE_TO_CHECK }}
+#          PRISMA_ACCESS_KEY: ${{ secrets.PRISMA_ACCESS_KEY }}
+#          PRISMA_ACCESS_KEY_SECRET: ${{ secrets.PRISMA_ACCESS_KEY_SECRET }}
+#          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+#          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+#          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+#        run: |
+#          export VIRTUAL_ENV=./venv
+#          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+#          cd ./.github/workflows/release_scripts/  && python3.8 prisma_vulnurability_checker.py
       - name: Prepare Maven Settings
         env:
           MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,7 +109,7 @@ jobs:
         run: |
           MANIFEST=$(aws ecr batch-get-image --repository-name ${{ github.event.repository.name }} --image-ids imageTag=main --region ${{ secrets.EMA_AWS_DEFAULT_REGION }} --output json | jq --raw-output '.images[].imageManifest')
           echo $MANIFEST
-#          aws ecr put-image --repository-name ${{ github.event.repository.name }} --image-tag ${{ github.event.inputs.releaseVersion }} --image-manifest \"\$MANIFEST\" --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+          aws ecr put-image --repository-name ${{ github.event.repository.name }} --image-tag ${{ github.event.inputs.releaseVersion }} --image-manifest "$MANIFEST" --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}
 #          
 #          ECR_REPO="${{ steps.login-ecr.outputs.registry }}/"
 #          MAIN_IMAGE="$ECR_REPO:main"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,14 +107,10 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1.6.0
       - name: ECR Docker Image Release
         run: |
-          MANIFEST=$(aws ecr batch-get-image --repository-name ${{ github.event.repository.name }} --image-ids imageTag=main --region ${{ secrets.EMA_AWS_DEFAULT_REGION }} --output json | jq --raw-output '.images[].imageManifest')
-          echo $MANIFEST
-          aws ecr put-image --repository-name ${{ github.event.repository.name }} --image-tag ${{ github.event.inputs.releaseVersion }} --image-manifest "$MANIFEST" --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}
-#          
-#          ECR_REPO="${{ steps.login-ecr.outputs.registry }}/"
-#          MAIN_IMAGE="$ECR_REPO:main"
-#          RELEASE_IMAGE="$ECR_REPO:${{ github.event.inputs.releaseVersion }}"
-#          echo "Release image : $RELEASE_IMAGE" 
-#          docker pull $MAIN_IMAGE  
-#          docker tag  $MAIN_IMAGE $RELEASE_IMAGE
-#          docker push $RELEASE_IMAGE
+          MANIFEST=$(aws ecr batch-get-image --repository-name ${{ github.event.repository.name }} \
+          --image-ids imageTag=main --region ${{ secrets.EMA_AWS_DEFAULT_REGION }} --output json \
+          | jq --raw-output '.images[].imageManifest')
+          
+          aws ecr put-image --repository-name ${{ github.event.repository.name }} \
+            --image-tag ${{ github.event.inputs.releaseVersion }} \
+            --image-manifest "$MANIFEST" --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,7 +105,7 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1.6.0
-      - name: Docker Build/Push
+      - name: ECR Docker Image Release
         run: |
           ECR_REPO="${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}"
           MAIN_IMAGE="$ECR_REPO:main"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,7 +109,7 @@ jobs:
         run: |
           ECR_REPO="${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}"
           MAIN_IMAGE="$ECR_REPO:main"
-          RELEASE_IMAGE = "$ECR_REPO:${{ github.event.inputs.releaseVersion }}"
+          RELEASE_IMAGE="$ECR_REPO:${{ github.event.inputs.releaseVersion }}"
           echo "main is $MAIN_IMAGE , release is $RELEASE_IMAGE" 
           docker pull $MAIN_IMAGE  
           docker tag  $MAIN_IMAGE $RELEASE_IMAGE

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,9 +107,9 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1.6.0
       - name: ECR Docker Image Release
         run: |
-          MANIFEST=$(aws ecr batch-get-image --repository-name ${{ github.event.repository.name }} --image-ids imageTag=main --query 'images[].imageManifest' --region ${{ secrets.EMA_AWS_DEFAULT_REGION }} --output text)
+          MANIFEST=$(aws ecr batch-get-image --repository-name ${{ github.event.repository.name }} --image-ids imageTag=main --region ${{ secrets.EMA_AWS_DEFAULT_REGION }} --output json | jq --raw-output '.images[].imageManifest')
           echo $MANIFEST
-          aws ecr put-image --repository-name ${{ github.event.repository.name }} --image-manifest-media-type 'application/vnd.oci.image.manifest.v1+json' --image-tag ${{ github.event.inputs.releaseVersion }} --image-manifest \"\$MANIFEST\" --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+#          aws ecr put-image --repository-name ${{ github.event.repository.name }} --image-tag ${{ github.event.inputs.releaseVersion }} --image-manifest \"\$MANIFEST\" --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}
 #          
 #          ECR_REPO="${{ steps.login-ecr.outputs.registry }}/"
 #          MAIN_IMAGE="$ECR_REPO:main"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,41 +20,41 @@ jobs:
         with:
           fetch-depth: 0
 
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: 11
-#          distribution: 'temurin'
-#          cache: 'maven'
-#      - name: Pre-Release Check - Version
-#        env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
-#          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
-#          if [[ ! -z "$release_version_exists" ]]; then
-#                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
-#                exit 1
-#          else
-#                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
-#          fi
-#      - name: Set up Python 3.8
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: 3.8
-#          cache: 'pip'
-#      - name: Pre-Release Check - Whitesource vulnurabilities
-#        env:
-#          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-#          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-#          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-#          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-#          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
-#        run: |
-#          pip install --quiet --upgrade pip
-#          export VIRTUAL_ENV=./venv
-#          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-#          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Pre-Release Check - Version
+        env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
+          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
+          if [[ ! -z "$release_version_exists" ]]; then
+                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
+                exit 1
+          else
+                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
+          fi
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          cache: 'pip'
+      - name: Pre-Release Check - Whitesource vulnurabilities
+        env:
+          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+        run: |
+          pip install --quiet --upgrade pip
+          export VIRTUAL_ENV=./venv
+          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
 #      - name: Pre-Release Check - Prisma vulnurabilities
 #        env:
 #          PRISMA_ROOT_API_URL: ${{ secrets.PRISMA_ROOT_API_URL }}
@@ -68,34 +68,34 @@ jobs:
 #          export VIRTUAL_ENV=./venv
 #          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
 #          cd ./.github/workflows/release_scripts/  && python3.8 prisma_vulnurability_checker.py
-#      - name: Prepare Maven Settings
-#        env:
-#          MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"
-#          MAVEN_REPO_SERVER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
-#          MAVEN_REPO_SERVER_PRIVATE_KEY: "~/.ssh/id_rsa"
-#          SSH_PRIVATE_KEY: "${{ secrets.COMMIT_KEY }}"
-#        run: cd .github/workflows/release_scripts && ./setup-ssh.sh
-#      - name: Set Release Configs
-#        run: |
-#          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
-#          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
-#          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-#
-#      - name: Maven Release
-#        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
-#      - name: Changelog
-#        uses: Bullrich/generate-release-changelog@master
-#        id: Changelog
-#        env:
-#          REPO: ${{ github.repository }}
-#      - name: Create GitHub Release
-#        uses: ncipollo/release-action@v1
-#        with:
-#          tag: "v${{ github.event.inputs.releaseVersion }}"
-#          artifacts: "**/application/target/*.jar"
-#          generateReleaseNotes: true
-#          makeLatest: true
-#          body: ${{ steps.Changelog.outputs.changelog }}
+      - name: Prepare Maven Settings
+        env:
+          MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"
+          MAVEN_REPO_SERVER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
+          MAVEN_REPO_SERVER_PRIVATE_KEY: "~/.ssh/id_rsa"
+          SSH_PRIVATE_KEY: "${{ secrets.COMMIT_KEY }}"
+        run: cd .github/workflows/release_scripts && ./setup-ssh.sh
+      - name: Set Release Configs
+        run: |
+          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
+          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
+          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
+
+      - name: Maven Release
+        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
+      - name: Changelog
+        uses: Bullrich/generate-release-changelog@master
+        id: Changelog
+        env:
+          REPO: ${{ github.repository }}
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "v${{ github.event.inputs.releaseVersion }}"
+          artifacts: "**/application/target/*.jar"
+          generateReleaseNotes: true
+          makeLatest: true
+          body: ${{ steps.Changelog.outputs.changelog }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,7 +109,7 @@ jobs:
         run: |
           MANIFEST=$(aws ecr batch-get-image --repository-name ${{ github.event.repository.name }} --image-ids imageTag=main --query 'images[].imageManifest' --region ${{ secrets.EMA_AWS_DEFAULT_REGION }} --output text)
           echo $MANIFEST
-          aws ecr put-image --repository-name ${{ github.event.repository.name }} --image-tag ${{ github.event.inputs.releaseVersion }} --image-manifest \"\$MANIFEST\" --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+          aws ecr put-image --repository-name ${{ github.event.repository.name }} --image-manifest-media-type 'application/vnd.oci.image.manifest.v1+json' --image-tag ${{ github.event.inputs.releaseVersion }} --image-manifest \"\$MANIFEST\" --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}
 #          
 #          ECR_REPO="${{ steps.login-ecr.outputs.registry }}/"
 #          MAIN_IMAGE="$ECR_REPO:main"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,82 +20,82 @@ jobs:
         with:
           fetch-depth: 0
 
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: 11
-#          distribution: 'temurin'
-#          cache: 'maven'
-#      - name: Pre-Release Check - Version
-#        env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
-#          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
-#          if [[ ! -z "$release_version_exists" ]]; then
-#                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
-#                exit 1
-#          else
-#                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
-#          fi
-#      - name: Set up Python 3.8
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: 3.8
-#          cache: 'pip'
-#      - name: Pre-Release Check - Whitesource vulnurabilities
-#        env:
-#          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-#          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-#          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-#          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-#          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
-#        run: |
-#          pip install --quiet --upgrade pip
-#          export VIRTUAL_ENV=./venv
-#          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-#          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
-#      - name: Pre-Release Check - Prisma vulnurabilities
-#        env:
-#          PRISMA_ROOT_API_URL: ${{ secrets.PRISMA_ROOT_API_URL }}
-#          DOCKER_IMAGE_TO_CHECK: ${{ secrets.PRISMA_DOCKER_IMAGE_TO_CHECK }}
-#          PRISMA_ACCESS_KEY: ${{ secrets.PRISMA_ACCESS_KEY }}
-#          PRISMA_ACCESS_KEY_SECRET: ${{ secrets.PRISMA_ACCESS_KEY_SECRET }}
-#          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-#          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-#          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
-#        run: |
-#          export VIRTUAL_ENV=./venv
-#          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-#          cd ./.github/workflows/release_scripts/  && python3.8 prisma_vulnurability_checker.py
-#      - name: Prepare Maven Settings
-#        env:
-#          MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"
-#          MAVEN_REPO_SERVER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
-#          MAVEN_REPO_SERVER_PRIVATE_KEY: "~/.ssh/id_rsa"
-#          SSH_PRIVATE_KEY: "${{ secrets.COMMIT_KEY }}"
-#        run: cd .github/workflows/release_scripts && ./setup-ssh.sh
-#      - name: Set Release Configs
-#        run: |
-#          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
-#          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
-#          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-#
-#      - name: Maven Release
-#        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
-#      - name: Changelog
-#        uses: Bullrich/generate-release-changelog@master
-#        id: Changelog
-#        env:
-#          REPO: ${{ github.repository }}
-#      - name: Create GitHub Release
-#        uses: ncipollo/release-action@v1
-#        with:
-#          tag: "v${{ github.event.inputs.releaseVersion }}"
-#          artifacts: "**/application/target/*.jar"
-#          generateReleaseNotes: true
-#          makeLatest: true
-#          body: ${{ steps.Changelog.outputs.changelog }}
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Pre-Release Check - Version
+        env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
+          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
+          if [[ ! -z "$release_version_exists" ]]; then
+                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
+                exit 1
+          else
+                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
+          fi
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          cache: 'pip'
+      - name: Pre-Release Check - Whitesource vulnurabilities
+        env:
+          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+        run: |
+          pip install --quiet --upgrade pip
+          export VIRTUAL_ENV=./venv
+          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
+      - name: Pre-Release Check - Prisma vulnurabilities
+        env:
+          PRISMA_ROOT_API_URL: ${{ secrets.PRISMA_ROOT_API_URL }}
+          DOCKER_IMAGE_TO_CHECK: ${{ secrets.PRISMA_DOCKER_IMAGE_TO_CHECK }}
+          PRISMA_ACCESS_KEY: ${{ secrets.PRISMA_ACCESS_KEY }}
+          PRISMA_ACCESS_KEY_SECRET: ${{ secrets.PRISMA_ACCESS_KEY_SECRET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+        run: |
+          export VIRTUAL_ENV=./venv
+          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+          cd ./.github/workflows/release_scripts/  && python3.8 prisma_vulnurability_checker.py
+      - name: Prepare Maven Settings
+        env:
+          MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"
+          MAVEN_REPO_SERVER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
+          MAVEN_REPO_SERVER_PRIVATE_KEY: "~/.ssh/id_rsa"
+          SSH_PRIVATE_KEY: "${{ secrets.COMMIT_KEY }}"
+        run: cd .github/workflows/release_scripts && ./setup-ssh.sh
+      - name: Set Release Configs
+        run: |
+          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
+          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
+          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
+
+      - name: Maven Release
+        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
+      - name: Changelog
+        uses: Bullrich/generate-release-changelog@master
+        id: Changelog
+        env:
+          REPO: ${{ github.repository }}
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "v${{ github.event.inputs.releaseVersion }}"
+          artifacts: "**/application/target/*.jar"
+          generateReleaseNotes: true
+          makeLatest: true
+          body: ${{ steps.Changelog.outputs.changelog }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,12 +96,12 @@ jobs:
 #          generateReleaseNotes: true
 #          makeLatest: true
 #          body: ${{ steps.Changelog.outputs.changelog }}
-#      - name: Configure AWS credentials
-#        uses: aws-actions/configure-aws-credentials@v2
-#        with:
-#          aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-#          aws-region: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1.6.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,7 +108,8 @@ jobs:
       - name: ECR Docker Image Release
         run: |
           MANIFEST=$(aws ecr batch-get-image --repository-name ${{ github.event.repository.name }} --image-ids imageTag=main --query 'images[].imageManifest' --region ${{ secrets.EMA_AWS_DEFAULT_REGION }} --output text)
-          aws ecr put-image --repository-name ${{ github.event.repository.name }} --image-tag ${{ github.event.inputs.releaseVersion }} --image-manifest $MANIFEST --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+          echo $MANIFEST
+#          aws ecr put-image --repository-name ${{ github.event.repository.name }} --image-tag ${{ github.event.inputs.releaseVersion }} --image-manifest $MANIFEST --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}
 #          
 #          ECR_REPO="${{ steps.login-ecr.outputs.registry }}/"
 #          MAIN_IMAGE="$ECR_REPO:main"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,7 +110,7 @@ jobs:
           ECR_REPO="${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}"
           MAIN_IMAGE="$ECR_REPO:main"
           RELEASE_IMAGE="$ECR_REPO:${{ github.event.inputs.releaseVersion }}"
-          echo "main is $MAIN_IMAGE , release is $RELEASE_IMAGE" 
+          echo "Release image : $RELEASE_IMAGE" 
           docker pull $MAIN_IMAGE  
           docker tag  $MAIN_IMAGE $RELEASE_IMAGE
           docker push $RELEASE_IMAGE

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,7 +107,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1.6.0
       - name: ECR Docker Image Release
         run: |
-          MANIFEST = $(aws ecr batch-get-image --repository-name ${{ github.event.repository.name }} --image-ids imageTag=main --query 'images[].imageManifest' --region ${{ secrets.EMA_AWS_DEFAULT_REGION }} --output text)
+          MANIFEST=$(aws ecr batch-get-image --repository-name ${{ github.event.repository.name }} --image-ids imageTag=main --query 'images[].imageManifest' --region ${{ secrets.EMA_AWS_DEFAULT_REGION }} --output text)
           aws ecr put-image --repository-name ${{ github.event.repository.name }} --image-tag ${{ github.event.inputs.releaseVersion }} --image-manifest $MANIFEST --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}
 #          
 #          ECR_REPO="${{ steps.login-ecr.outputs.registry }}/"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,41 +20,41 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: 'temurin'
-          cache: 'maven'
-      - name: Pre-Release Check - Version
-        env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
-          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
-          if [[ ! -z "$release_version_exists" ]]; then
-                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
-                exit 1
-          else
-                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
-          fi
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-          cache: 'pip'
-      - name: Pre-Release Check - Whitesource vulnurabilities
-        env:
-          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
-        run: |
-          pip install --quiet --upgrade pip
-          export VIRTUAL_ENV=./venv
-          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: 11
+#          distribution: 'temurin'
+#          cache: 'maven'
+#      - name: Pre-Release Check - Version
+#        env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
+#          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
+#          if [[ ! -z "$release_version_exists" ]]; then
+#                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
+#                exit 1
+#          else
+#                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
+#          fi
+#      - name: Set up Python 3.8
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: 3.8
+#          cache: 'pip'
+#      - name: Pre-Release Check - Whitesource vulnurabilities
+#        env:
+#          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+#          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+#          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+#          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+#          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+#        run: |
+#          pip install --quiet --upgrade pip
+#          export VIRTUAL_ENV=./venv
+#          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+#          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
 #      - name: Pre-Release Check - Prisma vulnurabilities
 #        env:
 #          PRISMA_ROOT_API_URL: ${{ secrets.PRISMA_ROOT_API_URL }}
@@ -68,49 +68,52 @@ jobs:
 #          export VIRTUAL_ENV=./venv
 #          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
 #          cd ./.github/workflows/release_scripts/  && python3.8 prisma_vulnurability_checker.py
-      - name: Prepare Maven Settings
-        env:
-          MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"
-          MAVEN_REPO_SERVER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
-          MAVEN_REPO_SERVER_PRIVATE_KEY: "~/.ssh/id_rsa"
-          SSH_PRIVATE_KEY: "${{ secrets.COMMIT_KEY }}"
-        run: cd .github/workflows/release_scripts && ./setup-ssh.sh
-      - name: Set Release Configs
-        run: |
-          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
-          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
-          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-
-      - name: Maven Release
-        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
-      - name: Changelog
-        uses: Bullrich/generate-release-changelog@master
-        id: Changelog
-        env:
-          REPO: ${{ github.repository }}
-      - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: "v${{ github.event.inputs.releaseVersion }}"
-          artifacts: "**/application/target/*.jar"
-          generateReleaseNotes: true
-          makeLatest: true
-          body: ${{ steps.Changelog.outputs.changelog }}
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+#      - name: Prepare Maven Settings
+#        env:
+#          MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"
+#          MAVEN_REPO_SERVER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
+#          MAVEN_REPO_SERVER_PRIVATE_KEY: "~/.ssh/id_rsa"
+#          SSH_PRIVATE_KEY: "${{ secrets.COMMIT_KEY }}"
+#        run: cd .github/workflows/release_scripts && ./setup-ssh.sh
+#      - name: Set Release Configs
+#        run: |
+#          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
+#          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
+#          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
+#
+#      - name: Maven Release
+#        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
+#      - name: Changelog
+#        uses: Bullrich/generate-release-changelog@master
+#        id: Changelog
+#        env:
+#          REPO: ${{ github.repository }}
+#      - name: Create GitHub Release
+#        uses: ncipollo/release-action@v1
+#        with:
+#          tag: "v${{ github.event.inputs.releaseVersion }}"
+#          artifacts: "**/application/target/*.jar"
+#          generateReleaseNotes: true
+#          makeLatest: true
+#          body: ${{ steps.Changelog.outputs.changelog }}
+#      - name: Configure AWS credentials
+#        uses: aws-actions/configure-aws-credentials@v2
+#        with:
+#          aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+#          aws-region: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1.6.0
       - name: ECR Docker Image Release
         run: |
-          ECR_REPO="${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}"
-          MAIN_IMAGE="$ECR_REPO:main"
-          RELEASE_IMAGE="$ECR_REPO:${{ github.event.inputs.releaseVersion }}"
-          echo "Release image : $RELEASE_IMAGE" 
-          docker pull $MAIN_IMAGE  
-          docker tag  $MAIN_IMAGE $RELEASE_IMAGE
-          docker push $RELEASE_IMAGE
+          MANIFEST = $(aws ecr batch-get-image --repository-name ${{ github.event.repository.name }} --image-ids imageTag=main --query 'images[].imageManifest' --region ${{ secrets.EMA_AWS_DEFAULT_REGION }} --output text)
+          aws ecr put-image --repository-name ${{ github.event.repository.name }} --image-tag ${{ github.event.inputs.releaseVersion }} --image-manifest $MANIFEST --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+#          
+#          ECR_REPO="${{ steps.login-ecr.outputs.registry }}/"
+#          MAIN_IMAGE="$ECR_REPO:main"
+#          RELEASE_IMAGE="$ECR_REPO:${{ github.event.inputs.releaseVersion }}"
+#          echo "Release image : $RELEASE_IMAGE" 
+#          docker pull $MAIN_IMAGE  
+#          docker tag  $MAIN_IMAGE $RELEASE_IMAGE
+#          docker push $RELEASE_IMAGE

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,79 +20,97 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: 11
+#          distribution: 'temurin'
+#          cache: 'maven'
+#      - name: Pre-Release Check - Version
+#        env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
+#          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
+#          if [[ ! -z "$release_version_exists" ]]; then
+#                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
+#                exit 1
+#          else
+#                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
+#          fi
+#      - name: Set up Python 3.8
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: 3.8
+#          cache: 'pip'
+#      - name: Pre-Release Check - Whitesource vulnurabilities
+#        env:
+#          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+#          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+#          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+#          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+#          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+#        run: |
+#          pip install --quiet --upgrade pip
+#          export VIRTUAL_ENV=./venv
+#          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+#          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
+#      - name: Pre-Release Check - Prisma vulnurabilities
+#        env:
+#          PRISMA_ROOT_API_URL: ${{ secrets.PRISMA_ROOT_API_URL }}
+#          DOCKER_IMAGE_TO_CHECK: ${{ secrets.PRISMA_DOCKER_IMAGE_TO_CHECK }}
+#          PRISMA_ACCESS_KEY: ${{ secrets.PRISMA_ACCESS_KEY }}
+#          PRISMA_ACCESS_KEY_SECRET: ${{ secrets.PRISMA_ACCESS_KEY_SECRET }}
+#          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+#          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+#          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+#        run: |
+#          export VIRTUAL_ENV=./venv
+#          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+#          cd ./.github/workflows/release_scripts/  && python3.8 prisma_vulnurability_checker.py
+#      - name: Prepare Maven Settings
+#        env:
+#          MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"
+#          MAVEN_REPO_SERVER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
+#          MAVEN_REPO_SERVER_PRIVATE_KEY: "~/.ssh/id_rsa"
+#          SSH_PRIVATE_KEY: "${{ secrets.COMMIT_KEY }}"
+#        run: cd .github/workflows/release_scripts && ./setup-ssh.sh
+#      - name: Set Release Configs
+#        run: |
+#          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
+#          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
+#          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
+#
+#      - name: Maven Release
+#        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
+#      - name: Changelog
+#        uses: Bullrich/generate-release-changelog@master
+#        id: Changelog
+#        env:
+#          REPO: ${{ github.repository }}
+#      - name: Create GitHub Release
+#        uses: ncipollo/release-action@v1
+#        with:
+#          tag: "v${{ github.event.inputs.releaseVersion }}"
+#          artifacts: "**/application/target/*.jar"
+#          generateReleaseNotes: true
+#          makeLatest: true
+#          body: ${{ steps.Changelog.outputs.changelog }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          java-version: 11
-          distribution: 'temurin'
-          cache: 'maven'
-      - name: Pre-Release Check - Version
-        env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1.6.0
+      - name: Docker Build/Push
         run: |
-          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
-          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
-          if [[ ! -z "$release_version_exists" ]]; then
-                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
-                exit 1
-          else
-                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
-          fi
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-          cache: 'pip'
-      - name: Pre-Release Check - Whitesource vulnurabilities
-        env:
-          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
-        run: |
-          pip install --quiet --upgrade pip
-          export VIRTUAL_ENV=./venv
-          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
-      - name: Pre-Release Check - Prisma vulnurabilities
-        env:
-          PRISMA_ROOT_API_URL: ${{ secrets.PRISMA_ROOT_API_URL }}
-          DOCKER_IMAGE_TO_CHECK: ${{ secrets.PRISMA_DOCKER_IMAGE_TO_CHECK }}
-          PRISMA_ACCESS_KEY: ${{ secrets.PRISMA_ACCESS_KEY }}
-          PRISMA_ACCESS_KEY_SECRET: ${{ secrets.PRISMA_ACCESS_KEY_SECRET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
-        run: |
-          export VIRTUAL_ENV=./venv
-          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-          cd ./.github/workflows/release_scripts/  && python3.8 prisma_vulnurability_checker.py
-      - name: Prepare Maven Settings
-        env:
-          MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"
-          MAVEN_REPO_SERVER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
-          MAVEN_REPO_SERVER_PRIVATE_KEY: "~/.ssh/id_rsa"
-          SSH_PRIVATE_KEY: "${{ secrets.COMMIT_KEY }}"
-        run: cd .github/workflows/release_scripts && ./setup-ssh.sh
-      - name: Set Release Configs
-        run: |
-          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
-          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
-          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-
-      - name: Maven Release
-        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
-      - name: Changelog
-        uses: Bullrich/generate-release-changelog@master
-        id: Changelog
-        env:
-          REPO: ${{ github.repository }}
-      - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: "v${{ github.event.inputs.releaseVersion }}"
-          artifacts: "**/application/target/*.jar"
-          generateReleaseNotes: true
-          makeLatest: true
-          body: ${{ steps.Changelog.outputs.changelog }}
+          ECR_REPO="${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}"
+          MAIN_IMAGE="$ECR_REPO:main"
+          RELEASE_IMAGE = "$ECR_REPO:${{ github.event.inputs.releaseVersion }}"
+          echo "main is $MAIN_IMAGE , release is $RELEASE_IMAGE" 
+          docker pull $MAIN_IMAGE  
+          docker tag  $MAIN_IMAGE $RELEASE_IMAGE
+          docker push $RELEASE_IMAGE


### PR DESCRIPTION
### What is the purpose of this change?
At the end of release, push the main docker image with tag `release_version` (input of the release workflow) to ECR

### How was this change implemented?
Added a step to pull/tag the main image and push it to ECR.

### How was this change tested?
https://github.com/SolaceLabs/event-management-agent/actions/runs/5282947289/jobs/9558528560

### Is there anything the reviewers should focus on/be aware of?
I also commented PRisma check step until we raise Prisma Jiras