### PR TITLE
Introduce KafkaClientConfig to make Kafka AdminClient properties configurable.

### DIFF
--- a/service/application/src/main/resources/application.yml
+++ b/service/application/src/main/resources/application.yml
@@ -39,6 +39,27 @@ camel:
   springboot:
     use-mdc-logging: true
 
+kafka:
+  client:
+    config:
+      connections:
+        timeout:
+          value: 30_000
+          unit: milliseconds
+        max-idle:
+          value: 10_000
+          unit: milliseconds
+        request-timeout:
+          value: 5_000
+          unit: milliseconds
+      reconnections:
+        backoff:
+          value: 50
+          unit: milliseconds
+        max-backoff:
+          value: 1_000
+          unit: milliseconds
+
 eventPortal:
   runtimeAgentId: ${EP_RUNTIME_AGENT_ID:defaultAgentId}
   organizationId: ${EP_ORGANIZATION_ID:defaultOrgId}

--- a/service/application/src/main/resources/application.yml
+++ b/service/application/src/main/resources/application.yml
@@ -44,7 +44,7 @@ kafka:
     config:
       connections:
         timeout:
-          value: 30_000
+          value: 60_000
           unit: milliseconds
         max-idle:
           value: 10_000

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/TestConfig.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/TestConfig.java
@@ -149,7 +149,7 @@ public class TestConfig {
         when(kafkaClientConfig.getReconnections()).thenReturn(kafkaClientReconnection);
 
         when(kafkaClientConnection.getTimeout()).thenReturn(kafkaClientConnectionConfigTimeout);
-        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(30_000);
+        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(60_000);
         when(kafkaClientConnectionConfigTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
 
         when(kafkaClientConnection.getMaxIdle()).thenReturn(kafkaClientConnectionConfigMaxIdle);

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/TestConfig.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/TestConfig.java
@@ -3,6 +3,11 @@ package com.solace.maas.ep.event.management.agent;
 import com.solace.maas.ep.event.management.agent.messagingServices.RtoMessagingService;
 import com.solace.maas.ep.event.management.agent.plugin.config.VMRProperties;
 import com.solace.maas.ep.event.management.agent.plugin.config.eventPortal.EventPortalPluginProperties;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConnection;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConnectionConfig;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientReconnection;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientReconnectionConfig;
 import com.solace.maas.ep.event.management.agent.plugin.messagingService.RtoMessageBuilder;
 import com.solace.maas.ep.event.management.agent.plugin.vmr.VmrProcessor;
 import com.solace.maas.ep.event.management.agent.testConfigs.MessagingServiceTestConfig;
@@ -24,6 +29,7 @@ import org.springframework.context.annotation.Profile;
 
 import java.util.Properties;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -36,6 +42,7 @@ public class TestConfig {
 
     @Autowired
     ProducerTemplate producerTemplate;
+
     @Autowired
     private CamelContext camelContext;
 
@@ -110,5 +117,57 @@ public class TestConfig {
         IDGenerator idGenerator = new IDGenerator(idGeneratorProperties());
         idGenerator.setRandom(random());
         return idGenerator;
+    }
+
+    @Bean
+    @Primary
+    KafkaClientConnection kafkaClientConnection() {
+        return mock(KafkaClientConnection.class);
+    }
+
+    @Bean
+    @Primary
+    KafkaClientReconnection kafkaClientReconnection() {
+        return mock(KafkaClientReconnection.class);
+    }
+
+    @Bean
+    @Primary
+    public KafkaClientConfig kafkaClientConfig() {
+        KafkaClientConfig kafkaClientConfig = mock(KafkaClientConfig.class);
+        KafkaClientConnection kafkaClientConnection = mock(KafkaClientConnection.class);
+        KafkaClientReconnection kafkaClientReconnection = mock(KafkaClientReconnection.class);
+
+        KafkaClientConnectionConfig kafkaClientConnectionConfigTimeout = mock(KafkaClientConnectionConfig.class);
+        KafkaClientConnectionConfig kafkaClientConnectionConfigMaxIdle = mock(KafkaClientConnectionConfig.class);
+        KafkaClientConnectionConfig kafkaClientConnectionConfigRequestTimeout = mock(KafkaClientConnectionConfig.class);
+
+        KafkaClientReconnectionConfig kafkaClientReconnectionConfigBackoff = mock(KafkaClientReconnectionConfig.class);
+        KafkaClientReconnectionConfig kafkaClientReconnectionConfigBackoffMax = mock(KafkaClientReconnectionConfig.class);
+
+        when(kafkaClientConfig.getConnections()).thenReturn(kafkaClientConnection);
+        when(kafkaClientConfig.getReconnections()).thenReturn(kafkaClientReconnection);
+
+        when(kafkaClientConnection.getTimeout()).thenReturn(kafkaClientConnectionConfigTimeout);
+        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(30_000);
+        when(kafkaClientConnectionConfigTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientConnection.getMaxIdle()).thenReturn(kafkaClientConnectionConfigMaxIdle);
+        when(kafkaClientConnectionConfigMaxIdle.getValue()).thenReturn(10_000);
+        when(kafkaClientConnectionConfigMaxIdle.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientConnection.getRequestTimeout()).thenReturn(kafkaClientConnectionConfigRequestTimeout);
+        when(kafkaClientConnectionConfigRequestTimeout.getValue()).thenReturn(5_000);
+        when(kafkaClientConnectionConfigRequestTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientReconnection.getBackoff()).thenReturn(kafkaClientReconnectionConfigBackoff);
+        when(kafkaClientReconnectionConfigBackoff.getValue()).thenReturn(50);
+        when(kafkaClientReconnectionConfigBackoff.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientReconnection.getMaxBackoff()).thenReturn(kafkaClientReconnectionConfigBackoffMax);
+        when(kafkaClientReconnectionConfigBackoffMax.getValue()).thenReturn(1000);
+        when(kafkaClientReconnectionConfigBackoffMax.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        return kafkaClientConfig;
     }
 }

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/cluster/KafkaBrokerConfigurationProcessor.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/cluster/KafkaBrokerConfigurationProcessor.java
@@ -2,6 +2,7 @@ package com.solace.maas.ep.event.management.agent.plugin.kafka.processor.cluster
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.cluster.KafkaBrokerConfigurationEvent;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.cluster.KafkaClusterConfigurationEvent;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.general.KafkaConfigurationEntryEvent;
@@ -25,11 +26,16 @@ import java.util.stream.Collectors;
 public class KafkaBrokerConfigurationProcessor extends ResultProcessorImpl<List<KafkaBrokerConfigurationEvent>,
         List<KafkaClusterConfigurationEvent>> {
     private final MessagingServiceDelegateService messagingServiceDelegateService;
+    private final long timeout;
+    private final TimeUnit timeUnit;
 
     @Autowired
-    public KafkaBrokerConfigurationProcessor(MessagingServiceDelegateService messagingServiceDelegateService) {
+    public KafkaBrokerConfigurationProcessor(MessagingServiceDelegateService messagingServiceDelegateService,
+                                             KafkaClientConfig kafkaClientConfig) {
         super();
         this.messagingServiceDelegateService = messagingServiceDelegateService;
+        timeout = kafkaClientConfig.getConnections().getTimeout().getValue();
+        timeUnit = kafkaClientConfig.getConnections().getTimeout().getUnit();
     }
 
     @Override
@@ -45,7 +51,7 @@ public class KafkaBrokerConfigurationProcessor extends ResultProcessorImpl<List<
                 .collect(Collectors.toUnmodifiableList());
 
         return adminClient.describeConfigs(brokers).all()
-                .get(30, TimeUnit.SECONDS)
+                .get(timeout, timeUnit)
                 .entrySet()
                 .stream()
                 .map(result -> {

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/cluster/KafkaClusterConfigurationProcessor.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/cluster/KafkaClusterConfigurationProcessor.java
@@ -2,6 +2,7 @@ package com.solace.maas.ep.event.management.agent.plugin.kafka.processor.cluster
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.cluster.KafkaClusterConfigurationEvent;
 import com.solace.maas.ep.event.management.agent.plugin.processor.base.ResultProcessorImpl;
 import com.solace.maas.ep.event.management.agent.plugin.service.MessagingServiceDelegateService;
@@ -21,11 +22,16 @@ import java.util.stream.Collectors;
 @SuppressWarnings("PMD")
 public class KafkaClusterConfigurationProcessor extends ResultProcessorImpl<List<KafkaClusterConfigurationEvent>, Void> {
     private final MessagingServiceDelegateService messagingServiceDelegateService;
+    private final long timeout;
+    private final TimeUnit timeUnit;
 
     @Autowired
-    public KafkaClusterConfigurationProcessor(MessagingServiceDelegateService messagingServiceDelegateService) {
+    public KafkaClusterConfigurationProcessor(MessagingServiceDelegateService messagingServiceDelegateService,
+                                              KafkaClientConfig kafkaClientConfig) {
         super();
         this.messagingServiceDelegateService = messagingServiceDelegateService;
+        timeout = kafkaClientConfig.getConnections().getTimeout().getValue();
+        timeUnit = kafkaClientConfig.getConnections().getTimeout().getUnit();
     }
 
     @Override
@@ -37,7 +43,7 @@ public class KafkaClusterConfigurationProcessor extends ResultProcessorImpl<List
 
         return adminClient.describeCluster()
                 .nodes()
-                .get(30, TimeUnit.SECONDS)
+                .get(timeout, timeUnit)
                 .stream()
                 .map(node -> KafkaClusterConfigurationEvent.builder()
                         .id(node.idString())

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/consumer/KafkaConsumerGroupConfigurationProcessor.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/consumer/KafkaConsumerGroupConfigurationProcessor.java
@@ -1,6 +1,7 @@
 package com.solace.maas.ep.event.management.agent.plugin.kafka.processor.consumer;
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.consumer.ConsumerEvent;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.consumer.ConsumerTopicPartitionEvent;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.consumer.KafkaConsumerGroupConfigurationEvent;
@@ -33,11 +34,16 @@ public class KafkaConsumerGroupConfigurationProcessor extends
         ResultProcessorImpl<List<KafkaConsumerGroupConfigurationEvent>, List<KafkaConsumerGroupEvent>> {
 
     private final MessagingServiceDelegateService messagingServiceDelegateService;
+    private final long timeout;
+    private final TimeUnit timeUnit;
 
     @Autowired
-    public KafkaConsumerGroupConfigurationProcessor(MessagingServiceDelegateService messagingServiceDelegateService) {
+    public KafkaConsumerGroupConfigurationProcessor(MessagingServiceDelegateService messagingServiceDelegateService,
+                                                    KafkaClientConfig kafkaClientConfig) {
         super();
         this.messagingServiceDelegateService = messagingServiceDelegateService;
+        timeout = kafkaClientConfig.getConnections().getTimeout().getValue();
+        timeUnit = kafkaClientConfig.getConnections().getTimeout().getUnit();
     }
 
     private KafkaConsumerGroupEvent mapConsumerGroupEvent(ConsumerGroupDescription consumerGroupDescription) {
@@ -123,7 +129,7 @@ public class KafkaConsumerGroupConfigurationProcessor extends
         Map<String, ConsumerGroupDescription> ConsumerGroupDescriptionMap =
                 describeConsumerGroupsResult
                         .all()
-                        .get(30, TimeUnit.SECONDS);
+                        .get(timeout, timeUnit);
 
         ConsumerGroupDescriptionMap
                 .forEach((key, consumerGroupDescription) -> {

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/consumer/KafkaConsumerGroupProcessor.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/consumer/KafkaConsumerGroupProcessor.java
@@ -1,6 +1,7 @@
 package com.solace.maas.ep.event.management.agent.plugin.kafka.processor.consumer;
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.consumer.KafkaConsumerGroupEvent;
 import com.solace.maas.ep.event.management.agent.plugin.processor.base.ResultProcessorImpl;
 import com.solace.maas.ep.event.management.agent.plugin.service.MessagingServiceDelegateService;
@@ -23,11 +24,16 @@ import java.util.stream.Collectors;
 @Component
 public class KafkaConsumerGroupProcessor extends ResultProcessorImpl<List<KafkaConsumerGroupEvent>, Void> {
     private final MessagingServiceDelegateService messagingServiceDelegateService;
+    private final long timeout;
+    private final TimeUnit timeUnit;
 
     @Autowired
-    public KafkaConsumerGroupProcessor(MessagingServiceDelegateService messagingServiceDelegateService) {
+    public KafkaConsumerGroupProcessor(MessagingServiceDelegateService messagingServiceDelegateService,
+                                       KafkaClientConfig kafkaClientConfig) {
         super();
         this.messagingServiceDelegateService = messagingServiceDelegateService;
+        timeout = kafkaClientConfig.getConnections().getTimeout().getValue();
+        timeUnit = kafkaClientConfig.getConnections().getTimeout().getUnit();
     }
 
     @Override
@@ -39,7 +45,7 @@ public class KafkaConsumerGroupProcessor extends ResultProcessorImpl<List<KafkaC
         ListConsumerGroupsResult listConsumerGroupsResult = adminClient.listConsumerGroups();
 
         Collection<ConsumerGroupListing> consumerGroupListings = listConsumerGroupsResult.all()
-                .get(30, TimeUnit.SECONDS);
+                .get(timeout, timeUnit);
 
         return consumerGroupListings
                 .stream()

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/feature/KafkaFeaturesProcessor.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/feature/KafkaFeaturesProcessor.java
@@ -2,6 +2,7 @@ package com.solace.maas.ep.event.management.agent.plugin.kafka.processor.feature
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.feature.KafkaFeatureEvent;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
 import com.solace.maas.ep.event.management.agent.plugin.processor.base.ResultProcessorImpl;
 import com.solace.maas.ep.event.management.agent.plugin.service.MessagingServiceDelegateService;
 import lombok.extern.slf4j.Slf4j;
@@ -19,11 +20,16 @@ import java.util.stream.Collectors;
 @Component
 public class KafkaFeaturesProcessor extends ResultProcessorImpl<List<KafkaFeatureEvent>, Void> {
     private final MessagingServiceDelegateService messagingServiceDelegateService;
+    private final long timeout;
+    private final TimeUnit timeUnit;
 
     @Autowired
-    public KafkaFeaturesProcessor(MessagingServiceDelegateService messagingServiceDelegateService) {
+    public KafkaFeaturesProcessor(MessagingServiceDelegateService messagingServiceDelegateService,
+                                  KafkaClientConfig kafkaClientConfig) {
         super();
         this.messagingServiceDelegateService = messagingServiceDelegateService;
+        timeout = kafkaClientConfig.getConnections().getTimeout().getValue();
+        timeUnit = kafkaClientConfig.getConnections().getTimeout().getUnit();
     }
 
     @Override
@@ -35,7 +41,7 @@ public class KafkaFeaturesProcessor extends ResultProcessorImpl<List<KafkaFeatur
 
         List<KafkaFeatureEvent> finalizedFeatures = new ArrayList<>(adminClient.describeFeatures()
                 .featureMetadata()
-                .get(30, TimeUnit.SECONDS)
+                .get(timeout, timeUnit)
                 .finalizedFeatures()
                 .entrySet()
                 .stream()
@@ -49,7 +55,7 @@ public class KafkaFeaturesProcessor extends ResultProcessorImpl<List<KafkaFeatur
 
         List<KafkaFeatureEvent> supportedFeatures = adminClient.describeFeatures()
                 .featureMetadata()
-                .get(30, TimeUnit.SECONDS)
+                .get(timeout, timeUnit)
                 .supportedFeatures()
                 .entrySet()
                 .stream()

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/topic/KafkaOverrideTopicConfigurationProcessor.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/topic/KafkaOverrideTopicConfigurationProcessor.java
@@ -2,6 +2,7 @@ package com.solace.maas.ep.event.management.agent.plugin.kafka.processor.topic;
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.general.KafkaConfigurationEntryEvent;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.topic.KafkaOverrideTopicConfigurationEvent;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.topic.KafkaTopicEvent;
@@ -25,11 +26,16 @@ import java.util.stream.Collectors;
 public class KafkaOverrideTopicConfigurationProcessor
         extends ResultProcessorImpl<List<KafkaOverrideTopicConfigurationEvent>, List<KafkaTopicEvent>> {
     private final MessagingServiceDelegateService messagingServiceDelegateService;
+    private final long timeout;
+    private final TimeUnit timeUnit;
 
     @Autowired
-    public KafkaOverrideTopicConfigurationProcessor(MessagingServiceDelegateService messagingServiceDelegateService) {
+    public KafkaOverrideTopicConfigurationProcessor(MessagingServiceDelegateService messagingServiceDelegateService,
+                                                    KafkaClientConfig kafkaClientConfig) {
         super();
         this.messagingServiceDelegateService = messagingServiceDelegateService;
+        timeout = kafkaClientConfig.getConnections().getTimeout().getValue();
+        timeUnit = kafkaClientConfig.getConnections().getTimeout().getUnit();
     }
 
     @Override
@@ -45,7 +51,7 @@ public class KafkaOverrideTopicConfigurationProcessor
 
             if (!configs.isEmpty()) {
                 return adminClient.describeConfigs(configs).all()
-                        .get(30, TimeUnit.SECONDS)
+                        .get(timeout, timeUnit)
                         .entrySet()
                         .stream()
                         .map(result -> {

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/topic/KafkaTopicListingProcessor.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/topic/KafkaTopicListingProcessor.java
@@ -1,6 +1,7 @@
 package com.solace.maas.ep.event.management.agent.plugin.kafka.processor.topic;
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.topic.KafkaTopicEvent;
 import com.solace.maas.ep.event.management.agent.plugin.processor.base.ResultProcessorImpl;
 import com.solace.maas.ep.event.management.agent.plugin.service.MessagingServiceDelegateService;
@@ -22,11 +23,16 @@ import java.util.stream.Collectors;
 @Component
 public class KafkaTopicListingProcessor extends ResultProcessorImpl<List<KafkaTopicEvent>, Void> {
     private final MessagingServiceDelegateService messagingServiceDelegateService;
+    private final long timeout;
+    private final TimeUnit timeUnit;
 
     @Autowired
-    public KafkaTopicListingProcessor(MessagingServiceDelegateService messagingServiceDelegateService) {
+    public KafkaTopicListingProcessor(MessagingServiceDelegateService messagingServiceDelegateService,
+                                      KafkaClientConfig kafkaClientConfig) {
         super();
         this.messagingServiceDelegateService = messagingServiceDelegateService;
+        timeout = kafkaClientConfig.getConnections().getTimeout().getValue();
+        timeUnit = kafkaClientConfig.getConnections().getTimeout().getUnit();
     }
 
     @Override
@@ -38,7 +44,7 @@ public class KafkaTopicListingProcessor extends ResultProcessorImpl<List<KafkaTo
 
         ListTopicsResult listTopicsResult = adminClient.listTopics();
         Collection<TopicListing> topicListings = listTopicsResult.listings()
-                .get(30, TimeUnit.SECONDS);
+                .get(timeout, timeUnit);
 
         return topicListings
                 .stream()

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/topic/KafkaTopicProducerProcessor.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/topic/KafkaTopicProducerProcessor.java
@@ -2,6 +2,7 @@ package com.solace.maas.ep.event.management.agent.plugin.kafka.processor.topic;
 
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.jacoco.ExcludeFromJacocoGeneratedReport;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.producer.KafkaProducerEvent;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.producer.KafkaProducerStateEvent;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.topic.KafkaTopicConfigurationEvent;
@@ -26,11 +27,16 @@ import java.util.stream.Collectors;
 @SuppressWarnings("PMD")
 public class KafkaTopicProducerProcessor extends ResultProcessorImpl<List<KafkaProducerEvent>, List<KafkaTopicConfigurationEvent>> {
     private final MessagingServiceDelegateService messagingServiceDelegateService;
+    private final long timeout;
+    private final TimeUnit timeUnit;
 
     @Autowired
-    public KafkaTopicProducerProcessor(MessagingServiceDelegateService messagingServiceDelegateService) {
+    public KafkaTopicProducerProcessor(MessagingServiceDelegateService messagingServiceDelegateService,
+                                       KafkaClientConfig kafkaClientConfig) {
         super();
         this.messagingServiceDelegateService = messagingServiceDelegateService;
+        timeout = kafkaClientConfig.getConnections().getTimeout().getValue();
+        timeUnit = kafkaClientConfig.getConnections().getTimeout().getUnit();
     }
 
     @Override
@@ -48,7 +54,7 @@ public class KafkaTopicProducerProcessor extends ResultProcessorImpl<List<KafkaP
             DescribeProducersResult describeProducersResult = adminClient.describeProducers(partitions);
 
             return describeProducersResult.all()
-                    .get(30, TimeUnit.SECONDS)
+                    .get(timeout, timeUnit)
                     .entrySet()
                     .stream()
                     .map(entries -> {

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/manager/client/KafkaClientConfigImpl.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/manager/client/KafkaClientConfigImpl.java
@@ -1,10 +1,11 @@
 package com.solace.maas.ep.event.management.agent.plugin.manager.client;
 
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class KafkaClientConfigImpl extends MessagingServiceClientConfig {
-    protected KafkaClientConfigImpl() {
-        super("KAFKA", new KafkaClientManagerImpl());
+    protected KafkaClientConfigImpl(KafkaClientConfig kafkaClientConfig) {
+        super("KAFKA", new KafkaClientManagerImpl(kafkaClientConfig));
     }
 }

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/manager/client/kafkaClient/KafkaClientConfig.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/manager/client/kafkaClient/KafkaClientConfig.java
@@ -1,0 +1,20 @@
+package com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Data
+@Builder
+@Configuration
+@EnableAutoConfiguration
+@PropertySource("classpath:application.yml")
+@ConfigurationProperties(prefix = "kafka.client.config")
+public class KafkaClientConfig {
+    KafkaClientConnection connections;
+    KafkaClientReconnection reconnections;
+}

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/manager/client/kafkaClient/KafkaClientConnection.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/manager/client/kafkaClient/KafkaClientConnection.java
@@ -1,0 +1,18 @@
+package com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Configuration
+public class KafkaClientConnection {
+    private KafkaClientConnectionConfig timeout;
+    private KafkaClientConnectionConfig maxIdle;
+    private KafkaClientConnectionConfig requestTimeout;
+}

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/manager/client/kafkaClient/KafkaClientConnectionConfig.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/manager/client/kafkaClient/KafkaClientConnectionConfig.java
@@ -1,0 +1,18 @@
+package com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.concurrent.TimeUnit;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KafkaClientConnectionConfig {
+    private int value;
+
+    private TimeUnit unit;
+}

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/manager/client/kafkaClient/KafkaClientReconnection.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/manager/client/kafkaClient/KafkaClientReconnection.java
@@ -1,0 +1,17 @@
+package com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Configuration
+public class KafkaClientReconnection {
+    private KafkaClientReconnectionConfig backoff;
+    private KafkaClientReconnectionConfig maxBackoff;
+}

--- a/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/manager/client/kafkaClient/KafkaClientReconnectionConfig.java
+++ b/service/kafka-plugin/src/main/java/com/solace/maas/ep/event/management/agent/plugin/manager/client/kafkaClient/KafkaClientReconnectionConfig.java
@@ -1,0 +1,17 @@
+package com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.concurrent.TimeUnit;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KafkaClientReconnectionConfig {
+    private int value;
+    private TimeUnit unit;
+}

--- a/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/KafkaTestConfig.java
+++ b/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/KafkaTestConfig.java
@@ -1,5 +1,10 @@
 package com.solace.maas.ep.event.management.agent.plugin;
 
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConnection;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConnectionConfig;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientReconnection;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientReconnectionConfig;
 import com.solace.maas.ep.event.management.agent.plugin.processor.EmptyScanEntityProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.processor.logging.MDCProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.route.manager.RouteManager;
@@ -8,7 +13,10 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 @TestConfiguration
@@ -17,6 +25,46 @@ public class KafkaTestConfig {
     @Primary
     public MessagingServiceDelegateService messagingServiceDelegateService() {
         return mock(MessagingServiceDelegateService.class);
+    }
+
+    @Bean
+    @Primary
+    public KafkaClientConfig kafkaClientConfig() {
+        KafkaClientConfig kafkaClientConfig = mock(KafkaClientConfig.class);
+        KafkaClientConnection kafkaClientConnection = mock(KafkaClientConnection.class);
+        KafkaClientReconnection kafkaClientReconnection = mock(KafkaClientReconnection.class);
+
+        KafkaClientConnectionConfig kafkaClientConnectionConfigTimeout = mock(KafkaClientConnectionConfig.class);
+        KafkaClientConnectionConfig kafkaClientConnectionConfigMaxIdle = mock(KafkaClientConnectionConfig.class);
+        KafkaClientConnectionConfig kafkaClientConnectionConfigRequestTimeout = mock(KafkaClientConnectionConfig.class);
+
+        KafkaClientReconnectionConfig kafkaClientReconnectionConfigBackoff = mock(KafkaClientReconnectionConfig.class);
+        KafkaClientReconnectionConfig kafkaClientReconnectionConfigBackoffMax = mock(KafkaClientReconnectionConfig.class);
+
+        when(kafkaClientConfig.getConnections()).thenReturn(kafkaClientConnection);
+        when(kafkaClientConfig.getReconnections()).thenReturn(kafkaClientReconnection);
+
+        when(kafkaClientConnection.getTimeout()).thenReturn(kafkaClientConnectionConfigTimeout);
+        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(30_000);
+        when(kafkaClientConnectionConfigTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientConnection.getMaxIdle()).thenReturn(kafkaClientConnectionConfigMaxIdle);
+        when(kafkaClientConnectionConfigMaxIdle.getValue()).thenReturn(10_000);
+        when(kafkaClientConnectionConfigMaxIdle.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientConnection.getRequestTimeout()).thenReturn(kafkaClientConnectionConfigRequestTimeout);
+        when(kafkaClientConnectionConfigRequestTimeout.getValue()).thenReturn(5_000);
+        when(kafkaClientConnectionConfigRequestTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientReconnection.getBackoff()).thenReturn(kafkaClientReconnectionConfigBackoff);
+        when(kafkaClientReconnectionConfigBackoff.getValue()).thenReturn(50);
+        when(kafkaClientReconnectionConfigBackoff.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientReconnection.getMaxBackoff()).thenReturn(kafkaClientReconnectionConfigBackoffMax);
+        when(kafkaClientReconnectionConfigBackoffMax.getValue()).thenReturn(1000);
+        when(kafkaClientReconnectionConfigBackoffMax.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        return kafkaClientConfig;
     }
 
     @Bean

--- a/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/KafkaTestConfig.java
+++ b/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/KafkaTestConfig.java
@@ -45,7 +45,7 @@ public class KafkaTestConfig {
         when(kafkaClientConfig.getReconnections()).thenReturn(kafkaClientReconnection);
 
         when(kafkaClientConnection.getTimeout()).thenReturn(kafkaClientConnectionConfigTimeout);
-        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(30_000);
+        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(60_000);
         when(kafkaClientConnectionConfigTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
 
         when(kafkaClientConnection.getMaxIdle()).thenReturn(kafkaClientConnectionConfigMaxIdle);

--- a/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/client/KafkaClientManagerTests.java
+++ b/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/client/KafkaClientManagerTests.java
@@ -1,32 +1,89 @@
-package com.solace.maas.ep.event.management.agent.plugin.manager.client;
+package com.solace.maas.ep.event.management.agent.plugin.kafka.client;
 
+import com.solace.maas.ep.event.management.agent.plugin.KafkaTestConfig;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.KafkaClientManagerImpl;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConnection;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConnectionConfig;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientReconnection;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientReconnectionConfig;
 import com.solace.maas.ep.event.management.agent.plugin.messagingService.event.AuthenticationDetailsEvent;
 import com.solace.maas.ep.event.management.agent.plugin.messagingService.event.ConnectionDetailsEvent;
 import com.solace.maas.ep.event.management.agent.plugin.messagingService.event.CredentialDetailsEvent;
 import com.solace.maas.ep.event.management.agent.plugin.messagingService.event.EventProperty;
+import lombok.SneakyThrows;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.SslConfigs;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-public class KafkaClientManagerTests {
+@ActiveProfiles("TEST")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KafkaTestConfig.class)
+class KafkaClientManagerTests {
 
-    private final KafkaClientManagerImpl kafkaClientManager = new KafkaClientManagerImpl();
+    @Mock
+    KafkaClientConfig kafkaClientConfig;
 
+    @BeforeEach
+    void setupMocks() {
+        KafkaClientConnection kafkaClientConnection = mock(KafkaClientConnection.class);
+        KafkaClientReconnection kafkaClientReconnection = mock(KafkaClientReconnection.class);
+
+        KafkaClientConnectionConfig kafkaClientConnectionConfigTimeout = mock(KafkaClientConnectionConfig.class);
+        KafkaClientConnectionConfig kafkaClientConnectionConfigMaxIdle = mock(KafkaClientConnectionConfig.class);
+        KafkaClientConnectionConfig kafkaClientConnectionConfigRequestTimeout = mock(KafkaClientConnectionConfig.class);
+
+        KafkaClientReconnectionConfig kafkaClientReconnectionConfigBackoff = mock(KafkaClientReconnectionConfig.class);
+        KafkaClientReconnectionConfig kafkaClientReconnectionConfigBackoffMax = mock(KafkaClientReconnectionConfig.class);
+
+        when(kafkaClientConfig.getConnections()).thenReturn(kafkaClientConnection);
+        when(kafkaClientConfig.getReconnections()).thenReturn(kafkaClientReconnection);
+
+        when(kafkaClientConnection.getTimeout()).thenReturn(kafkaClientConnectionConfigTimeout);
+        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(30_000);
+        when(kafkaClientConnectionConfigTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientConnection.getMaxIdle()).thenReturn(kafkaClientConnectionConfigMaxIdle);
+        when(kafkaClientConnectionConfigMaxIdle.getValue()).thenReturn(10_000);
+        when(kafkaClientConnectionConfigMaxIdle.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientConnection.getRequestTimeout()).thenReturn(kafkaClientConnectionConfigRequestTimeout);
+        when(kafkaClientConnectionConfigRequestTimeout.getValue()).thenReturn(5_000);
+        when(kafkaClientConnectionConfigRequestTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientReconnection.getBackoff()).thenReturn(kafkaClientReconnectionConfigBackoff);
+        when(kafkaClientReconnectionConfigBackoff.getValue()).thenReturn(50);
+        when(kafkaClientReconnectionConfigBackoff.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientReconnection.getMaxBackoff()).thenReturn(kafkaClientReconnectionConfigBackoffMax);
+        when(kafkaClientReconnectionConfigBackoffMax.getValue()).thenReturn(1000);
+        when(kafkaClientReconnectionConfigBackoffMax.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+    }
+
+    @SneakyThrows
     @Test
-    public void testProperties() {
+    void testProperties() {
+        KafkaClientManagerImpl kafkaClientManager = new KafkaClientManagerImpl(kafkaClientConfig);
+
         ConnectionDetailsEvent connectionDetailsEvent = ConnectionDetailsEvent.builder()
                 .url("connection_url")
                 .messagingServiceId("messaging_service_id")
@@ -57,7 +114,9 @@ public class KafkaClientManagerTests {
     }
 
     @Test
-    public void adminClientCreatePassThroughCredentialProperties() {
+    void adminClientCreatePassThroughCredentialProperties() {
+        KafkaClientManagerImpl kafkaClientManager = new KafkaClientManagerImpl(kafkaClientConfig);
+
         ConnectionDetailsEvent connectionDetailsEvent = ConnectionDetailsEvent.builder()
                 .url("localhost:12345")
                 .messagingServiceId("messaging_service_id")
@@ -89,7 +148,9 @@ public class KafkaClientManagerTests {
     }
 
     @Test
-    public void adminClientCreateFailure() {
+    void adminClientCreateFailure() {
+        KafkaClientManagerImpl kafkaClientManager = new KafkaClientManagerImpl(kafkaClientConfig);
+
         ConnectionDetailsEvent connectionDetailsEvent = ConnectionDetailsEvent.builder()
                 .url("connection_url")
                 .messagingServiceId("messaging_service_id")

--- a/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/client/KafkaClientManagerTests.java
+++ b/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/client/KafkaClientManagerTests.java
@@ -59,7 +59,7 @@ class KafkaClientManagerTests {
         when(kafkaClientConfig.getReconnections()).thenReturn(kafkaClientReconnection);
 
         when(kafkaClientConnection.getTimeout()).thenReturn(kafkaClientConnectionConfigTimeout);
-        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(30_000);
+        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(60_000);
         when(kafkaClientConnectionConfigTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
 
         when(kafkaClientConnection.getMaxIdle()).thenReturn(kafkaClientConnectionConfigMaxIdle);
@@ -102,15 +102,17 @@ class KafkaClientManagerTests {
                 .build();
 
         Properties properties = kafkaClientManager.buildProperties(connectionDetailsEvent);
-        assertThat(properties.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo("connection_url");
-        assertThat(properties.get(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG)).isEqualTo(10000);
-        assertThat(properties.get(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG)).isEqualTo(5000);
-        assertThat(properties.get(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG)).isEqualTo("SSL");
-        assertThat(properties.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG)).isEqualTo("/trust/location/truststore.jks");
-        assertThat(properties.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG)).isEqualTo("trustpass");
-        assertThat(properties.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG)).isEqualTo("keypass");
-        assertThat(properties.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG)).isEqualTo("/trust/location/keystore.jks");
-        assertThat(properties.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG)).isEqualTo("keyPass");
+        
+        assertThat(properties)
+                .containsEntry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "connection_url")
+                .containsEntry(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG, 10000)
+                .containsEntry(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, 5000)
+                .containsEntry(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL")
+                .containsEntry(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "/trust/location/truststore.jks")
+                .containsEntry(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, "trustpass")
+                .containsEntry(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "keypass")
+                .containsEntry(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, "/trust/location/keystore.jks")
+                .containsEntry(SslConfigs.SSL_KEY_PASSWORD_CONFIG, "keyPass");
     }
 
     @Test

--- a/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaBrokerConfigurationProcessorTests.java
+++ b/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaBrokerConfigurationProcessorTests.java
@@ -63,7 +63,7 @@ class KafkaBrokerConfigurationProcessorTests {
         when(kafkaClientConfig.getReconnections()).thenReturn(kafkaClientReconnection);
 
         when(kafkaClientConnection.getTimeout()).thenReturn(kafkaClientConnectionConfigTimeout);
-        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(30_000);
+        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(60_000);
         when(kafkaClientConnectionConfigTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
 
         when(kafkaClientConnection.getMaxIdle()).thenReturn(kafkaClientConnectionConfigMaxIdle);
@@ -120,7 +120,7 @@ class KafkaBrokerConfigurationProcessorTests {
                 .thenReturn(describeConfigsResult);
         when(describeConfigsResult.all())
                 .thenReturn(future);
-        when(future.get(30_000, TimeUnit.MILLISECONDS))
+        when(future.get(60_000, TimeUnit.MILLISECONDS))
                 .thenReturn(Map.of(configResource, config));
 
         List<KafkaBrokerConfigurationEvent> kafkaBrokerConfigurationEvents =

--- a/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaClusterConfigurationProcessorTests.java
+++ b/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaClusterConfigurationProcessorTests.java
@@ -59,7 +59,7 @@ class KafkaClusterConfigurationProcessorTests {
         when(kafkaClientConfig.getReconnections()).thenReturn(kafkaClientReconnection);
 
         when(kafkaClientConnection.getTimeout()).thenReturn(kafkaClientConnectionConfigTimeout);
-        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(30_000);
+        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(60_000);
         when(kafkaClientConnectionConfigTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
 
         when(kafkaClientConnection.getMaxIdle()).thenReturn(kafkaClientConnectionConfigMaxIdle);
@@ -96,7 +96,7 @@ class KafkaClusterConfigurationProcessorTests {
                 .thenReturn(describeClusterResult);
         when(describeClusterResult.nodes())
                 .thenReturn(future);
-        when(future.get(30_000, TimeUnit.MILLISECONDS))
+        when(future.get(60_000, TimeUnit.MILLISECONDS))
                 .thenReturn(List.of(node1, node2));
 
         List<KafkaClusterConfigurationEvent> kafkaClusterConfigurationEvents =

--- a/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaClusterConfigurationProcessorTests.java
+++ b/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaClusterConfigurationProcessorTests.java
@@ -2,55 +2,49 @@ package com.solace.maas.ep.event.management.agent.plugin.kafka.processor;
 
 import com.solace.maas.ep.event.management.agent.plugin.KafkaTestConfig;
 import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
-import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.topic.KafkaTopicConfigurationEvent;
-import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.topic.KafkaTopicEvent;
-import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.topic.KafkaTopicConfigurationProcessor;
+import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.cluster.KafkaClusterConfigurationProcessor;
+import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.cluster.KafkaClusterConfigurationEvent;
 import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
 import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConnection;
 import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConnectionConfig;
 import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientReconnection;
 import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientReconnectionConfig;
 import com.solace.maas.ep.event.management.agent.plugin.service.MessagingServiceDelegateService;
+import lombok.SneakyThrows;
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.DescribeTopicsResult;
-import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
-import org.apache.kafka.common.TopicPartitionInfo;
-import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.acl.AclOperation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ActiveProfiles("TEST")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KafkaTestConfig.class)
-@SuppressWarnings("PMD")
-class KafkaTopicConfigurationProcessorTests {
+class KafkaClusterConfigurationProcessorTests {
 
     @Mock
-    private MessagingServiceDelegateService messagingServiceDelegateService;
+    MessagingServiceDelegateService messagingServiceDelegateService;
 
     @Mock
-    private KafkaClientConfig kafkaClientConfig;
+    KafkaClientConfig kafkaClientConfig;
 
-    private KafkaTopicConfigurationProcessor kafkaTopicConfigurationProcessor;
+    private KafkaClusterConfigurationProcessor kafkaClusterConfigurationProcessor;
 
     @BeforeEach
-    void setupMocks() {
+    void mockSetup() {
         KafkaClientConnection kafkaClientConnection = mock(KafkaClientConnection.class);
         KafkaClientReconnection kafkaClientReconnection = mock(KafkaClientReconnection.class);
 
@@ -84,61 +78,44 @@ class KafkaTopicConfigurationProcessorTests {
         when(kafkaClientReconnectionConfigBackoffMax.getValue()).thenReturn(1000);
         when(kafkaClientReconnectionConfigBackoffMax.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
 
-        kafkaTopicConfigurationProcessor = new
-                KafkaTopicConfigurationProcessor(messagingServiceDelegateService, kafkaClientConfig);
+        kafkaClusterConfigurationProcessor = new KafkaClusterConfigurationProcessor(messagingServiceDelegateService, kafkaClientConfig);
     }
 
+    @SneakyThrows
     @Test
-    void testHandleEvents() throws Exception {
-        Node node = new Node(0, "host1", 9090);
-        TopicDescription topic1 = new TopicDescription(
-                "topic1",
-                false,
-                List.of(new TopicPartitionInfo(0, node, List.of(node), List.of(node))),
-                Set.of(AclOperation.CREATE),
-                Uuid.randomUuid());
-
+    void testHandleEvent() {
         AdminClient adminClient = mock(AdminClient.class);
-        DescribeTopicsResult describeTopicsResult = mock(DescribeTopicsResult.class);
-        KafkaFuture<Map<String, TopicDescription>> future = mock(KafkaFuture.class);
+        DescribeClusterResult describeClusterResult = mock(DescribeClusterResult.class);
+        KafkaFuture<Collection<Node>> future = mock(KafkaFuture.class);
 
+        Node node1 = new Node(0, "host1", 9090);
+        Node node2 = new Node(1, "host2", 9092);
         when(messagingServiceDelegateService.getMessagingServiceClient("testService"))
                 .thenReturn(adminClient);
-        when(adminClient.describeTopics(any(List.class)))
-                .thenReturn(describeTopicsResult);
-        when(describeTopicsResult.all()).thenReturn(future);
+        when(adminClient.describeCluster())
+                .thenReturn(describeClusterResult);
+        when(describeClusterResult.nodes())
+                .thenReturn(future);
         when(future.get(30_000, TimeUnit.MILLISECONDS))
-                .thenReturn(Map.of("0", topic1));
+                .thenReturn(List.of(node1, node2));
 
-        List<KafkaTopicConfigurationEvent> kafkaTopicConfigurationEvents =
-                kafkaTopicConfigurationProcessor.handleEvent(
-                        Map.of(RouteConstants.MESSAGING_SERVICE_ID, "testService"),
-                        List.of(
-                                KafkaTopicEvent.builder()
-                                        .name("topic1")
-                                        .topicId("id1")
-                                        .internal(false)
-                                        .build())
-                );
+        List<KafkaClusterConfigurationEvent> kafkaClusterConfigurationEvents =
+                kafkaClusterConfigurationProcessor.handleEvent(Map.of(RouteConstants.MESSAGING_SERVICE_ID, "testService"), null);
 
-        KafkaTopicConfigurationEvent kafkaTopicConfigurationEvent = kafkaTopicConfigurationEvents.get(0);
 
-        assertThat(kafkaTopicConfigurationEvents).hasSize(1);
-        assertThat(kafkaTopicConfigurationEvent.getTopicId()).isNotNull();
-        assertThat(kafkaTopicConfigurationEvent.getName()).isEqualTo("topic1");
-        assertThat(kafkaTopicConfigurationEvent.getAcls()).hasSize(1);
-        assertThat(kafkaTopicConfigurationEvent.getAcls().get(0).getName()).isEqualTo("CREATE");
-        assertThat(kafkaTopicConfigurationEvent.getPartitions()).hasSize(1);
-        assertThat(kafkaTopicConfigurationEvent.getPartitions().get(0).getReplicas()).hasSize(1);
-        assertThat(kafkaTopicConfigurationEvent.getPartitions().get(0).getIsr()).hasSize(1);
-        assertThat(kafkaTopicConfigurationEvent.getPartitions().get(0).getLeader().getHost()).isEqualTo("host1");
+        KafkaClusterConfigurationEvent firstEvent = kafkaClusterConfigurationEvents.stream()
+                .filter(element -> "0".equals(element.getId()))
+                .findFirst().orElseThrow();
 
-        List<KafkaTopicConfigurationEvent> empty =
-                kafkaTopicConfigurationProcessor.handleEvent(
-                        Map.of(RouteConstants.MESSAGING_SERVICE_ID, "testService"),
-                        List.of());
+        KafkaClusterConfigurationEvent secondEvent = kafkaClusterConfigurationEvents.stream()
+                .filter(element -> "1".equals(element.getId()))
+                .findFirst().orElseThrow();
 
-        assertThat(empty).isEmpty();
+        assertThat(kafkaClusterConfigurationEvents).hasSize(2);
+        assertThat(firstEvent.getPort()).isEqualTo(9090);
+        assertThat(firstEvent.getHost()).isEqualTo("host1");
+        assertThat(secondEvent.getPort()).isEqualTo(9092);
+        assertThat(secondEvent.getHost()).isEqualTo("host2");
 
         assertThatNoException();
     }

--- a/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaConsumerGroupConfigurationProcessorTests.java
+++ b/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaConsumerGroupConfigurationProcessorTests.java
@@ -67,7 +67,7 @@ class KafkaConsumerGroupConfigurationProcessorTests {
         when(kafkaClientConfig.getReconnections()).thenReturn(kafkaClientReconnection);
 
         when(kafkaClientConnection.getTimeout()).thenReturn(kafkaClientConnectionConfigTimeout);
-        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(30_000);
+        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(60_000);
         when(kafkaClientConnectionConfigTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
 
         when(kafkaClientConnection.getMaxIdle()).thenReturn(kafkaClientConnectionConfigMaxIdle);
@@ -118,7 +118,7 @@ class KafkaConsumerGroupConfigurationProcessorTests {
                 .thenReturn(describeConsumerGroupsResult);
         when(describeConsumerGroupsResult.all())
                 .thenReturn(future);
-        when(future.get(30_000, TimeUnit.MILLISECONDS))
+        when(future.get(60_000, TimeUnit.MILLISECONDS))
                 .thenReturn((ConsumerGroupDescriptionMap));
 
         kafkaConsumerGroupConfigurationProcessor.handleEvent(Map.of(RouteConstants.MESSAGING_SERVICE_ID, "messagingServiceId"),

--- a/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaConsumerGroupProcessorTests.java
+++ b/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaConsumerGroupProcessorTests.java
@@ -1,16 +1,21 @@
 package com.solace.maas.ep.event.management.agent.plugin.kafka.processor;
 
-import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.KafkaTestConfig;
+import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.consumer.KafkaConsumerGroupProcessor;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConnection;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConnectionConfig;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientReconnection;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientReconnectionConfig;
 import com.solace.maas.ep.event.management.agent.plugin.service.MessagingServiceDelegateService;
 import lombok.SneakyThrows;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
 import org.apache.kafka.clients.admin.ListConsumerGroupsResult;
 import org.apache.kafka.common.KafkaFuture;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -26,17 +31,57 @@ import static org.mockito.Mockito.when;
 
 @ActiveProfiles("TEST")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KafkaTestConfig.class)
-public class KafkaConsumerGroupProcessorTests {
+class KafkaConsumerGroupProcessorTests {
 
     @Mock
     private MessagingServiceDelegateService messagingServiceDelegateService;
 
-    @InjectMocks
+    @Mock
+    private KafkaClientConfig kafkaClientConfig;
+
     private KafkaConsumerGroupProcessor kafkaConsumerGroupProcessor;
+
+    @BeforeEach
+    void setupMocks() {
+        KafkaClientConnection kafkaClientConnection = mock(KafkaClientConnection.class);
+        KafkaClientReconnection kafkaClientReconnection = mock(KafkaClientReconnection.class);
+
+        KafkaClientConnectionConfig kafkaClientConnectionConfigTimeout = mock(KafkaClientConnectionConfig.class);
+        KafkaClientConnectionConfig kafkaClientConnectionConfigMaxIdle = mock(KafkaClientConnectionConfig.class);
+        KafkaClientConnectionConfig kafkaClientConnectionConfigRequestTimeout = mock(KafkaClientConnectionConfig.class);
+
+        KafkaClientReconnectionConfig kafkaClientReconnectionConfigBackoff = mock(KafkaClientReconnectionConfig.class);
+        KafkaClientReconnectionConfig kafkaClientReconnectionConfigBackoffMax = mock(KafkaClientReconnectionConfig.class);
+
+        when(kafkaClientConfig.getConnections()).thenReturn(kafkaClientConnection);
+        when(kafkaClientConfig.getReconnections()).thenReturn(kafkaClientReconnection);
+
+        when(kafkaClientConnection.getTimeout()).thenReturn(kafkaClientConnectionConfigTimeout);
+        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(30_000);
+        when(kafkaClientConnectionConfigTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientConnection.getMaxIdle()).thenReturn(kafkaClientConnectionConfigMaxIdle);
+        when(kafkaClientConnectionConfigMaxIdle.getValue()).thenReturn(10_000);
+        when(kafkaClientConnectionConfigMaxIdle.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientConnection.getRequestTimeout()).thenReturn(kafkaClientConnectionConfigRequestTimeout);
+        when(kafkaClientConnectionConfigRequestTimeout.getValue()).thenReturn(5_000);
+        when(kafkaClientConnectionConfigRequestTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientReconnection.getBackoff()).thenReturn(kafkaClientReconnectionConfigBackoff);
+        when(kafkaClientReconnectionConfigBackoff.getValue()).thenReturn(50);
+        when(kafkaClientReconnectionConfigBackoff.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientReconnection.getMaxBackoff()).thenReturn(kafkaClientReconnectionConfigBackoffMax);
+        when(kafkaClientReconnectionConfigBackoffMax.getValue()).thenReturn(1000);
+        when(kafkaClientReconnectionConfigBackoffMax.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        kafkaConsumerGroupProcessor = new KafkaConsumerGroupProcessor(messagingServiceDelegateService, kafkaClientConfig);
+    }
 
     @SneakyThrows
     @Test
-    public void testHandleEvent() {
+    void testHandleEvent() {
         AdminClient adminClient = mock(AdminClient.class);
         ListConsumerGroupsResult listConsumerGroupsResult = mock(ListConsumerGroupsResult.class);
         ConsumerGroupListing consumerGroupListings = mock(ConsumerGroupListing.class);
@@ -51,7 +96,7 @@ public class KafkaConsumerGroupProcessorTests {
         when(listConsumerGroupsResult.all())
                 .thenReturn(future);
 
-        when(future.get(30, TimeUnit.SECONDS))
+        when(future.get(30_000, TimeUnit.MILLISECONDS))
                 .thenReturn(List.of(consumerGroupListings));
 
         kafkaConsumerGroupProcessor.handleEvent(Map.of(RouteConstants.MESSAGING_SERVICE_ID, "messagingServiceId"), null);

--- a/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaConsumerGroupProcessorTests.java
+++ b/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaConsumerGroupProcessorTests.java
@@ -57,7 +57,7 @@ class KafkaConsumerGroupProcessorTests {
         when(kafkaClientConfig.getReconnections()).thenReturn(kafkaClientReconnection);
 
         when(kafkaClientConnection.getTimeout()).thenReturn(kafkaClientConnectionConfigTimeout);
-        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(30_000);
+        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(60_000);
         when(kafkaClientConnectionConfigTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
 
         when(kafkaClientConnection.getMaxIdle()).thenReturn(kafkaClientConnectionConfigMaxIdle);
@@ -96,7 +96,7 @@ class KafkaConsumerGroupProcessorTests {
         when(listConsumerGroupsResult.all())
                 .thenReturn(future);
 
-        when(future.get(30_000, TimeUnit.MILLISECONDS))
+        when(future.get(60_000, TimeUnit.MILLISECONDS))
                 .thenReturn(List.of(consumerGroupListings));
 
         kafkaConsumerGroupProcessor.handleEvent(Map.of(RouteConstants.MESSAGING_SERVICE_ID, "messagingServiceId"), null);

--- a/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaTopicConfigurationProcessorTests.java
+++ b/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaTopicConfigurationProcessorTests.java
@@ -1,16 +1,22 @@
 package com.solace.maas.ep.event.management.agent.plugin.kafka.processor;
 
 import com.solace.maas.ep.event.management.agent.plugin.KafkaTestConfig;
+import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.consumer.KafkaConsumerGroupConfigurationProcessor;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.event.topic.KafkaTopicEvent;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.topic.KafkaTopicConfigurationProcessor;
-import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConnection;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConnectionConfig;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientReconnection;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientReconnectionConfig;
 import com.solace.maas.ep.event.management.agent.plugin.service.MessagingServiceDelegateService;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaFuture;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -27,15 +33,57 @@ import static org.mockito.Mockito.when;
 @ActiveProfiles("TEST")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KafkaTestConfig.class)
 @SuppressWarnings("PMD")
-public class KafkaTopicConfigurationProcessorTests {
+class KafkaTopicConfigurationProcessorTests {
+
     @Mock
     private MessagingServiceDelegateService messagingServiceDelegateService;
 
-    @InjectMocks
+    @Mock
+    private KafkaClientConfig kafkaClientConfig;
+
     private KafkaTopicConfigurationProcessor kafkaTopicConfigurationProcessor;
 
+    @BeforeEach
+    void setupMocks() {
+        KafkaClientConnection kafkaClientConnection = mock(KafkaClientConnection.class);
+        KafkaClientReconnection kafkaClientReconnection = mock(KafkaClientReconnection.class);
+
+        KafkaClientConnectionConfig kafkaClientConnectionConfigTimeout = mock(KafkaClientConnectionConfig.class);
+        KafkaClientConnectionConfig kafkaClientConnectionConfigMaxIdle = mock(KafkaClientConnectionConfig.class);
+        KafkaClientConnectionConfig kafkaClientConnectionConfigRequestTimeout = mock(KafkaClientConnectionConfig.class);
+
+        KafkaClientReconnectionConfig kafkaClientReconnectionConfigBackoff = mock(KafkaClientReconnectionConfig.class);
+        KafkaClientReconnectionConfig kafkaClientReconnectionConfigBackoffMax = mock(KafkaClientReconnectionConfig.class);
+
+        when(kafkaClientConfig.getConnections()).thenReturn(kafkaClientConnection);
+        when(kafkaClientConfig.getReconnections()).thenReturn(kafkaClientReconnection);
+
+        when(kafkaClientConnection.getTimeout()).thenReturn(kafkaClientConnectionConfigTimeout);
+        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(30_000);
+        when(kafkaClientConnectionConfigTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientConnection.getMaxIdle()).thenReturn(kafkaClientConnectionConfigMaxIdle);
+        when(kafkaClientConnectionConfigMaxIdle.getValue()).thenReturn(10_000);
+        when(kafkaClientConnectionConfigMaxIdle.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientConnection.getRequestTimeout()).thenReturn(kafkaClientConnectionConfigRequestTimeout);
+        when(kafkaClientConnectionConfigRequestTimeout.getValue()).thenReturn(5_000);
+        when(kafkaClientConnectionConfigRequestTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientReconnection.getBackoff()).thenReturn(kafkaClientReconnectionConfigBackoff);
+        when(kafkaClientReconnectionConfigBackoff.getValue()).thenReturn(50);
+        when(kafkaClientReconnectionConfigBackoff.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientReconnection.getMaxBackoff()).thenReturn(kafkaClientReconnectionConfigBackoffMax);
+        when(kafkaClientReconnectionConfigBackoffMax.getValue()).thenReturn(1000);
+        when(kafkaClientReconnectionConfigBackoffMax.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        kafkaTopicConfigurationProcessor = new
+                KafkaTopicConfigurationProcessor(messagingServiceDelegateService, kafkaClientConfig);
+    }
+
     @Test
-    public void testHandleEvents() throws Exception {
+    void testHandleEvents() throws Exception {
         AdminClient adminClient = mock(AdminClient.class);
         DescribeTopicsResult describeTopicsResult = mock(DescribeTopicsResult.class);
         KafkaFuture<Map<String, TopicDescription>> future = mock(KafkaFuture.class);
@@ -45,7 +93,7 @@ public class KafkaTopicConfigurationProcessorTests {
         when(adminClient.describeTopics(any(List.class)))
                 .thenReturn(describeTopicsResult);
         when(describeTopicsResult.all()).thenReturn(future);
-        when(future.get(30, TimeUnit.SECONDS))
+        when(future.get(30_000, TimeUnit.MILLISECONDS))
                 .thenReturn(Map.of());
 
         kafkaTopicConfigurationProcessor.handleEvent(

--- a/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaTopicConfigurationProcessorTests.java
+++ b/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaTopicConfigurationProcessorTests.java
@@ -65,7 +65,7 @@ class KafkaTopicConfigurationProcessorTests {
         when(kafkaClientConfig.getReconnections()).thenReturn(kafkaClientReconnection);
 
         when(kafkaClientConnection.getTimeout()).thenReturn(kafkaClientConnectionConfigTimeout);
-        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(30_000);
+        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(60_000);
         when(kafkaClientConnectionConfigTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
 
         when(kafkaClientConnection.getMaxIdle()).thenReturn(kafkaClientConnectionConfigMaxIdle);
@@ -107,7 +107,7 @@ class KafkaTopicConfigurationProcessorTests {
         when(adminClient.describeTopics(any(List.class)))
                 .thenReturn(describeTopicsResult);
         when(describeTopicsResult.all()).thenReturn(future);
-        when(future.get(30_000, TimeUnit.MILLISECONDS))
+        when(future.get(60_000, TimeUnit.MILLISECONDS))
                 .thenReturn(Map.of("0", topic1));
 
         List<KafkaTopicConfigurationEvent> kafkaTopicConfigurationEvents =

--- a/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaTopicListingProcessorTests.java
+++ b/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaTopicListingProcessorTests.java
@@ -59,7 +59,7 @@ class KafkaTopicListingProcessorTests {
         when(kafkaClientConfig.getReconnections()).thenReturn(kafkaClientReconnection);
 
         when(kafkaClientConnection.getTimeout()).thenReturn(kafkaClientConnectionConfigTimeout);
-        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(30_000);
+        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(60_000);
         when(kafkaClientConnectionConfigTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
 
         when(kafkaClientConnection.getMaxIdle()).thenReturn(kafkaClientConnectionConfigMaxIdle);
@@ -93,7 +93,7 @@ class KafkaTopicListingProcessorTests {
                 .thenReturn(adminClient);
         when(adminClient.listTopics()).thenReturn(listTopicsResult);
         when(listTopicsResult.listings()).thenReturn(future);
-        when(future.get(30_000, TimeUnit.MILLISECONDS))
+        when(future.get(60_000, TimeUnit.MILLISECONDS))
                 .thenReturn(List.of(new TopicListing("name",
                         new Uuid(0L, 1L), true)));
 

--- a/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaTopicListingProcessorTests.java
+++ b/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/processor/KafkaTopicListingProcessorTests.java
@@ -1,8 +1,13 @@
 package com.solace.maas.ep.event.management.agent.plugin.kafka.processor;
 
-import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.KafkaTestConfig;
+import com.solace.maas.ep.event.management.agent.plugin.constants.RouteConstants;
 import com.solace.maas.ep.event.management.agent.plugin.kafka.processor.topic.KafkaTopicListingProcessor;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConfig;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConnection;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientConnectionConfig;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientReconnection;
+import com.solace.maas.ep.event.management.agent.plugin.manager.client.kafkaClient.KafkaClientReconnectionConfig;
 import com.solace.maas.ep.event.management.agent.plugin.service.MessagingServiceDelegateService;
 import lombok.SneakyThrows;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -10,8 +15,8 @@ import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.TopicListing;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Uuid;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -28,16 +33,58 @@ import static org.mockito.Mockito.when;
 @ActiveProfiles("TEST")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KafkaTestConfig.class)
 @SuppressWarnings("PMD")
-public class KafkaTopicListingProcessorTests {
+class KafkaTopicListingProcessorTests {
+
     @Mock
     private MessagingServiceDelegateService messagingServiceDelegateService;
 
-    @InjectMocks
+    @Mock
+    private KafkaClientConfig kafkaClientConfig;
+
     private KafkaTopicListingProcessor kafkaTopicListingProcessor;
+
+    @BeforeEach
+    void setupMocks() {
+        KafkaClientConnection kafkaClientConnection = mock(KafkaClientConnection.class);
+        KafkaClientReconnection kafkaClientReconnection = mock(KafkaClientReconnection.class);
+
+        KafkaClientConnectionConfig kafkaClientConnectionConfigTimeout = mock(KafkaClientConnectionConfig.class);
+        KafkaClientConnectionConfig kafkaClientConnectionConfigMaxIdle = mock(KafkaClientConnectionConfig.class);
+        KafkaClientConnectionConfig kafkaClientConnectionConfigRequestTimeout = mock(KafkaClientConnectionConfig.class);
+
+        KafkaClientReconnectionConfig kafkaClientReconnectionConfigBackoff = mock(KafkaClientReconnectionConfig.class);
+        KafkaClientReconnectionConfig kafkaClientReconnectionConfigBackoffMax = mock(KafkaClientReconnectionConfig.class);
+
+        when(kafkaClientConfig.getConnections()).thenReturn(kafkaClientConnection);
+        when(kafkaClientConfig.getReconnections()).thenReturn(kafkaClientReconnection);
+
+        when(kafkaClientConnection.getTimeout()).thenReturn(kafkaClientConnectionConfigTimeout);
+        when(kafkaClientConnectionConfigTimeout.getValue()).thenReturn(30_000);
+        when(kafkaClientConnectionConfigTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientConnection.getMaxIdle()).thenReturn(kafkaClientConnectionConfigMaxIdle);
+        when(kafkaClientConnectionConfigMaxIdle.getValue()).thenReturn(10_000);
+        when(kafkaClientConnectionConfigMaxIdle.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientConnection.getRequestTimeout()).thenReturn(kafkaClientConnectionConfigRequestTimeout);
+        when(kafkaClientConnectionConfigRequestTimeout.getValue()).thenReturn(5_000);
+        when(kafkaClientConnectionConfigRequestTimeout.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientReconnection.getBackoff()).thenReturn(kafkaClientReconnectionConfigBackoff);
+        when(kafkaClientReconnectionConfigBackoff.getValue()).thenReturn(50);
+        when(kafkaClientReconnectionConfigBackoff.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        when(kafkaClientReconnection.getMaxBackoff()).thenReturn(kafkaClientReconnectionConfigBackoffMax);
+        when(kafkaClientReconnectionConfigBackoffMax.getValue()).thenReturn(1000);
+        when(kafkaClientReconnectionConfigBackoffMax.getUnit()).thenReturn(TimeUnit.MILLISECONDS);
+
+        kafkaTopicListingProcessor = new
+                KafkaTopicListingProcessor(messagingServiceDelegateService, kafkaClientConfig);
+    }
 
     @SneakyThrows
     @Test
-    public void testHandleEvent() {
+    void testHandleEvent() {
         AdminClient adminClient = mock(AdminClient.class);
         ListTopicsResult listTopicsResult = mock(ListTopicsResult.class);
         KafkaFuture<Collection<TopicListing>> future = mock(KafkaFuture.class);
@@ -46,7 +93,7 @@ public class KafkaTopicListingProcessorTests {
                 .thenReturn(adminClient);
         when(adminClient.listTopics()).thenReturn(listTopicsResult);
         when(listTopicsResult.listings()).thenReturn(future);
-        when(future.get(30, TimeUnit.SECONDS))
+        when(future.get(30_000, TimeUnit.MILLISECONDS))
                 .thenReturn(List.of(new TopicListing("name",
                         new Uuid(0L, 1L), true)));
 

--- a/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/delegate/KafkaRouteDelegateImplTests.java
+++ b/service/kafka-plugin/src/test/java/com/solace/maas/ep/event/management/agent/plugin/kafka/route/delegate/KafkaRouteDelegateImplTests.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException
 
 @ActiveProfiles("TEST")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KafkaTestConfig.class)
-public class KafkaRouteDelegateImplTests {
+class KafkaRouteDelegateImplTests {
     @InjectMocks
     private KafkaRouteDelegateImpl kafkaRouteDelegate;
 
@@ -30,7 +30,7 @@ public class KafkaRouteDelegateImplTests {
     );
 
     @Test
-    public void testGenerateKafkaTopicListingRouteList() {
+    void testGenerateKafkaTopicListingRouteList() {
         List<RouteBundle> routeBundles =
                 kafkaRouteDelegate.generateRouteList(destinations, List.of(), KafkaScanType.KAFKA_TOPIC_LISTING.name(),
                 "service1");
@@ -40,7 +40,7 @@ public class KafkaRouteDelegateImplTests {
     }
 
     @Test
-    public void testGenerateKafkaTopicConfigurationRouteList() {
+    void testGenerateKafkaTopicConfigurationRouteList() {
         List<RouteBundle> routeBundles =
                 kafkaRouteDelegate.generateRouteList(destinations, List.of(), KafkaScanType.KAFKA_TOPIC_CONFIGURATION.name(),
                         "service1");
@@ -50,7 +50,7 @@ public class KafkaRouteDelegateImplTests {
     }
 
     @Test
-    public void testGenerateKafkaTopicConfigurationFullRouteList() {
+    void testGenerateKafkaTopicConfigurationFullRouteList() {
         List<RouteBundle> routeBundles =
                 kafkaRouteDelegate.generateRouteList(destinations, List.of(), KafkaScanType.KAFKA_TOPIC_CONFIGURATION_FULL.name(),
                         "service1");
@@ -60,7 +60,7 @@ public class KafkaRouteDelegateImplTests {
     }
 
     @Test
-    public void testGenerateKafkaConsumerGroupsRouteList() {
+    void testGenerateKafkaConsumerGroupsRouteList() {
         List<RouteBundle> routeBundles =
                 kafkaRouteDelegate.generateRouteList(destinations, List.of(), KafkaScanType.KAFKA_CONSUMER_GROUPS.name(),
                         "service1");
@@ -70,7 +70,7 @@ public class KafkaRouteDelegateImplTests {
     }
 
     @Test
-    public void testGenerateKafkaConsumerGroupsConfigRouteList() {
+    void testGenerateKafkaConsumerGroupsConfigRouteList() {
         List<RouteBundle> routeBundles =
                 kafkaRouteDelegate.generateRouteList(destinations, List.of(),
                         KafkaScanType.KAFKA_CONSUMER_GROUPS_CONFIGURATION.name(),
@@ -81,7 +81,7 @@ public class KafkaRouteDelegateImplTests {
     }
 
     @Test
-    public void testGenerateKafkaAllRouteList() {
+    void testGenerateKafkaAllRouteList() {
         List<RouteBundle> routeBundles =
                 kafkaRouteDelegate.generateRouteList(destinations, List.of(), KafkaScanType.KAFKA_ALL.name(),
                         "service1");


### PR DESCRIPTION
### What is the purpose of this change?

To make the following Kafka `AdminClient` properties configurable. 

- `timeout` for get requests.
- `connections.max.idle.ms`
- `reconnect.backoff.max.ms`
- `reconnect.backoff.ms`
- `request.timeout.ms`

### How was this change implemented?

By introducing the `KafkaClientConfig` and other related config objects. Also, updating related Kafka processors to utilize the new config.

### How was this change tested?

Manual by setting various values for Kafka AdminClient and run scans for Kafka brokers.

### Is there anything the reviewers should focus on/be aware of?

N/A
