### PR TITLE
Enabling Prisma Vulnerabilities check before release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,18 +26,18 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           cache: 'maven'
-#      - name: Pre-Release Check - Version
-#        env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
-#          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
-#          if [[ ! -z "$release_version_exists" ]]; then
-#                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
-#                exit 1
-#          else
-#                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
-#          fi
+      - name: Pre-Release Check - Version
+        env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
+          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
+          if [[ ! -z "$release_version_exists" ]]; then
+                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
+                exit 1
+          else
+                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
+          fi
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
@@ -76,49 +76,49 @@ jobs:
           export VIRTUAL_ENV=./venv
           python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
           cd ./.github/workflows/release_scripts/  && python3.8 prisma_vulnurability_checker.py
-#      - name: Prepare Maven Settings
-#        env:
-#          MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"
-#          MAVEN_REPO_SERVER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
-#          MAVEN_REPO_SERVER_PRIVATE_KEY: "~/.ssh/id_rsa"
-#          SSH_PRIVATE_KEY: "${{ secrets.COMMIT_KEY }}"
-#        run: cd .github/workflows/release_scripts && ./setup-ssh.sh
-#      - name: Set Release Configs
-#        run: |
-#          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
-#          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
-#          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-#
-#      - name: Maven Release
-#        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
-#      - name: Changelog
-#        uses: Bullrich/generate-release-changelog@master
-#        id: Changelog
-#        env:
-#          REPO: ${{ github.repository }}
-#      - name: Create GitHub Release
-#        uses: ncipollo/release-action@v1
-#        with:
-#          tag: "v${{ github.event.inputs.releaseVersion }}"
-#          artifacts: "**/application/target/*.jar"
-#          generateReleaseNotes: true
-#          makeLatest: true
-#          body: ${{ steps.Changelog.outputs.changelog }}
-#      - name: Configure AWS credentials
-#        uses: aws-actions/configure-aws-credentials@v2
-#        with:
-#          aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-#          aws-region: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
-#      - name: Login to Amazon ECR
-#        id: login-ecr
-#        uses: aws-actions/amazon-ecr-login@v1.6.0
-#      - name: ECR Docker Image Release
-#        run: |
-#          MANIFEST=$(aws ecr batch-get-image --repository-name ${{ github.event.repository.name }} \
-#          --image-ids imageTag=main --region ${{ secrets.EMA_AWS_DEFAULT_REGION }} --output json \
-#          | jq --raw-output '.images[].imageManifest')
-#
-#          aws ecr put-image --repository-name ${{ github.event.repository.name }} \
-#            --image-tag ${{ github.event.inputs.releaseVersion }} \
-#            --image-manifest "$MANIFEST" --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+      - name: Prepare Maven Settings
+        env:
+          MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"
+          MAVEN_REPO_SERVER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
+          MAVEN_REPO_SERVER_PRIVATE_KEY: "~/.ssh/id_rsa"
+          SSH_PRIVATE_KEY: "${{ secrets.COMMIT_KEY }}"
+        run: cd .github/workflows/release_scripts && ./setup-ssh.sh
+      - name: Set Release Configs
+        run: |
+          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
+          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
+          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
+
+      - name: Maven Release
+        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
+      - name: Changelog
+        uses: Bullrich/generate-release-changelog@master
+        id: Changelog
+        env:
+          REPO: ${{ github.repository }}
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: "v${{ github.event.inputs.releaseVersion }}"
+          artifacts: "**/application/target/*.jar"
+          generateReleaseNotes: true
+          makeLatest: true
+          body: ${{ steps.Changelog.outputs.changelog }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1.6.0
+      - name: ECR Docker Image Release
+        run: |
+          MANIFEST=$(aws ecr batch-get-image --repository-name ${{ github.event.repository.name }} \
+          --image-ids imageTag=main --region ${{ secrets.EMA_AWS_DEFAULT_REGION }} --output json \
+          | jq --raw-output '.images[].imageManifest')
+
+          aws ecr put-image --repository-name ${{ github.event.repository.name }} \
+            --image-tag ${{ github.event.inputs.releaseVersion }} \
+            --image-manifest "$MANIFEST" --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,11 +50,11 @@ jobs:
 #          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
 #          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
 #          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
-        run: |
-          pip install --quiet --upgrade pip
-          export VIRTUAL_ENV=./venv
-          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
+#        run: |
+#          pip install --quiet --upgrade pip
+#          export VIRTUAL_ENV=./venv
+#          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+#          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
       - name: Pre-Release Check - SonarQube Hotspots
         env:
           SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,13 +43,13 @@ jobs:
         with:
           python-version: 3.8
           cache: 'pip'
-      - name: Pre-Release Check - Whitesource vulnurabilities
-        env:
-          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+#      - name: Pre-Release Check - Whitesource vulnurabilities
+#        env:
+#          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+#          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+#          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+#          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+#          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
         run: |
           pip install --quiet --upgrade pip
           export VIRTUAL_ENV=./venv

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,19 +63,19 @@ jobs:
           export VIRTUAL_ENV=./venv
           python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
           cd ./.github/workflows/release_scripts/  && python3.8 sonarqube_vulnurability_checker.py
-#      - name: Pre-Release Check - Prisma vulnurabilities
-#        env:
-#          PRISMA_ROOT_API_URL: ${{ secrets.PRISMA_ROOT_API_URL }}
-#          DOCKER_IMAGE_TO_CHECK: ${{ secrets.PRISMA_DOCKER_IMAGE_TO_CHECK }}
-#          PRISMA_ACCESS_KEY: ${{ secrets.PRISMA_ACCESS_KEY }}
-#          PRISMA_ACCESS_KEY_SECRET: ${{ secrets.PRISMA_ACCESS_KEY_SECRET }}
-#          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-#          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-#          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
-#        run: |
-#          export VIRTUAL_ENV=./venv
-#          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-#          cd ./.github/workflows/release_scripts/  && python3.8 prisma_vulnurability_checker.py
+      - name: Pre-Release Check - Prisma vulnurabilities
+        env:
+          PRISMA_ROOT_API_URL: ${{ secrets.PRISMA_ROOT_API_URL }}
+          DOCKER_IMAGE_TO_CHECK: ${{ secrets.PRISMA_DOCKER_IMAGE_TO_CHECK }}
+          PRISMA_ACCESS_KEY: ${{ secrets.PRISMA_ACCESS_KEY }}
+          PRISMA_ACCESS_KEY_SECRET: ${{ secrets.PRISMA_ACCESS_KEY_SECRET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+        run: |
+          export VIRTUAL_ENV=./venv
+          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+          cd ./.github/workflows/release_scripts/  && python3.8 prisma_vulnurability_checker.py
       - name: Prepare Maven Settings
         env:
           MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,18 +43,18 @@ jobs:
         with:
           python-version: 3.8
           cache: 'pip'
-#      - name: Pre-Release Check - Whitesource vulnurabilities
-#        env:
-#          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
-#          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
-#          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-#          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-#          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
-#        run: |
-#          pip install --quiet --upgrade pip
-#          export VIRTUAL_ENV=./venv
-#          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
-#          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
+      - name: Pre-Release Check - Whitesource vulnurabilities
+        env:
+          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+        run: |
+          pip install --quiet --upgrade pip
+          export VIRTUAL_ENV=./venv
+          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
       - name: Pre-Release Check - SonarQube Hotspots
         env:
           SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,18 +26,18 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           cache: 'maven'
-      - name: Pre-Release Check - Version
-        env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
-          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
-          if [[ ! -z "$release_version_exists" ]]; then
-                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
-                exit 1
-          else
-                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
-          fi
+#      - name: Pre-Release Check - Version
+#        env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          gh api --method GET /repos/${{github.repository}}/releases -f sort=updated -f direction=asc > releases.json
+#          release_version_exists=$(jq -r --arg RELEASE_VERSION v${{ github.event.inputs.releaseVersion }} '.[].name|select(.|test($RELEASE_VERSION))'  releases.json)
+#          if [[ ! -z "$release_version_exists" ]]; then
+#                echo "Version ${{ github.event.inputs.releaseVersion }} has been previously released. Please change release version."
+#                exit 1
+#          else
+#                echo "New version: ${{ github.event.inputs.releaseVersion }} going to be released!"
+#          fi
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
@@ -76,49 +76,49 @@ jobs:
           export VIRTUAL_ENV=./venv
           python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
           cd ./.github/workflows/release_scripts/  && python3.8 prisma_vulnurability_checker.py
-      - name: Prepare Maven Settings
-        env:
-          MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"
-          MAVEN_REPO_SERVER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
-          MAVEN_REPO_SERVER_PRIVATE_KEY: "~/.ssh/id_rsa"
-          SSH_PRIVATE_KEY: "${{ secrets.COMMIT_KEY }}"
-        run: cd .github/workflows/release_scripts && ./setup-ssh.sh
-      - name: Set Release Configs
-        run: |
-          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
-          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
-          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
-
-      - name: Maven Release
-        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
-      - name: Changelog
-        uses: Bullrich/generate-release-changelog@master
-        id: Changelog
-        env:
-          REPO: ${{ github.repository }}
-      - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: "v${{ github.event.inputs.releaseVersion }}"
-          artifacts: "**/application/target/*.jar"
-          generateReleaseNotes: true
-          makeLatest: true
-          body: ${{ steps.Changelog.outputs.changelog }}
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1.6.0
-      - name: ECR Docker Image Release
-        run: |
-          MANIFEST=$(aws ecr batch-get-image --repository-name ${{ github.event.repository.name }} \
-          --image-ids imageTag=main --region ${{ secrets.EMA_AWS_DEFAULT_REGION }} --output json \
-          | jq --raw-output '.images[].imageManifest')
-
-          aws ecr put-image --repository-name ${{ github.event.repository.name }} \
-            --image-tag ${{ github.event.inputs.releaseVersion }} \
-            --image-manifest "$MANIFEST" --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+#      - name: Prepare Maven Settings
+#        env:
+#          MAVEN_REPO_SERVER_USERNAME: "${{ github.actor }}"
+#          MAVEN_REPO_SERVER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
+#          MAVEN_REPO_SERVER_PRIVATE_KEY: "~/.ssh/id_rsa"
+#          SSH_PRIVATE_KEY: "${{ secrets.COMMIT_KEY }}"
+#        run: cd .github/workflows/release_scripts && ./setup-ssh.sh
+#      - name: Set Release Configs
+#        run: |
+#          export SKIP_FLAGS_NON_UNIT_TESTS="-Dcheckstyle.skip -Dpmd.skip -Dcpd.skip -Dfindbugs.skip -Dspotbugs.skip"
+#          echo "SKIP_FLAGS_NON_UNIT_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS" >> $GITHUB_ENV
+#          echo "SKIP_FLAGS_ALL_TESTS=$SKIP_FLAGS_NON_UNIT_TESTS -Dmaven.test.skip=true" >> $GITHUB_ENV
+#
+#      - name: Maven Release
+#        run: mvn release:prepare release:perform -B --file service/pom.xml -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}
+#      - name: Changelog
+#        uses: Bullrich/generate-release-changelog@master
+#        id: Changelog
+#        env:
+#          REPO: ${{ github.repository }}
+#      - name: Create GitHub Release
+#        uses: ncipollo/release-action@v1
+#        with:
+#          tag: "v${{ github.event.inputs.releaseVersion }}"
+#          artifacts: "**/application/target/*.jar"
+#          generateReleaseNotes: true
+#          makeLatest: true
+#          body: ${{ steps.Changelog.outputs.changelog }}
+#      - name: Configure AWS credentials
+#        uses: aws-actions/configure-aws-credentials@v2
+#        with:
+#          aws-access-key-id: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+#          aws-region: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+#      - name: Login to Amazon ECR
+#        id: login-ecr
+#        uses: aws-actions/amazon-ecr-login@v1.6.0
+#      - name: ECR Docker Image Release
+#        run: |
+#          MANIFEST=$(aws ecr batch-get-image --repository-name ${{ github.event.repository.name }} \
+#          --image-ids imageTag=main --region ${{ secrets.EMA_AWS_DEFAULT_REGION }} --output json \
+#          | jq --raw-output '.images[].imageManifest')
+#
+#          aws ecr put-image --repository-name ${{ github.event.repository.name }} \
+#            --image-tag ${{ github.event.inputs.releaseVersion }} \
+#            --image-manifest "$MANIFEST" --region ${{ secrets.EMA_AWS_DEFAULT_REGION }}

--- a/.github/workflows/release_scripts/prisma_vulnurability_checker.py
+++ b/.github/workflows/release_scripts/prisma_vulnurability_checker.py
@@ -23,7 +23,7 @@ def get_excluded_packages():
 
     exclusions = set()
     for exclusion in whitesource_exclusion_entries:
-        exclusions.add(exclusion['package'])
+        exclusions.add(exclusion['packageName'])
 
     return exclusions
 


### PR DESCRIPTION
### What is the purpose of this change?
Checking that no high/critical reported for the latest EMA's docker image before release 

### How was this change implemented?
Enabling steps to call `prisma_vulnurability_checker.py`

Need to merge PR: https://github.com/SolaceDev/sc-cicd-security-tools/pull/27 first.