### PR TITLE
DATAGO-57633: Create a new workflow for EMA pre-release security checks

### DIFF
--- a/.github/workflows/release-readiness-check.yaml
+++ b/.github/workflows/release-readiness-check.yaml
@@ -1,6 +1,8 @@
 name: Release Readiness Checks
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   release:

--- a/.github/workflows/release-readiness-check.yaml
+++ b/.github/workflows/release-readiness-check.yaml
@@ -1,8 +1,6 @@
 name: Release Readiness Checks
 on:
-  push:
-    branches:
-      - add_workflow_check_prisma_ws
+  workflow_dispatch:
 
 jobs:
   pre_release_checks:

--- a/.github/workflows/release-readiness-check.yaml
+++ b/.github/workflows/release-readiness-check.yaml
@@ -30,7 +30,7 @@ jobs:
           python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
           cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
       - name: Pre-Release Check - SonarQube Hotspots
-        ${{ always() }}
+        if: ${{ always() }}
         env:
           SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}
           SONARQUBE_QUERY_TOKEN: ${{ secrets.SONARQUBE_QUERY_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
           python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
           cd ./.github/workflows/release_scripts/  && python3.8 sonarqube_vulnurability_checker.py
       - name: Pre-Release Check - Prisma vulnurabilities
-        ${{ always() }}
+        if: ${{ always() }}
         env:
           PRISMA_ROOT_API_URL: ${{ secrets.PRISMA_ROOT_API_URL }}
           DOCKER_IMAGE_TO_CHECK: ${{ secrets.PRISMA_DOCKER_IMAGE_TO_CHECK }}

--- a/.github/workflows/release-readiness-check.yaml
+++ b/.github/workflows/release-readiness-check.yaml
@@ -5,7 +5,7 @@ on:
       - add_workflow_check_prisma_ws
 
 jobs:
-  release:
+  pre_release_checks:
     runs-on: ubuntu-latest
     environment: prod
     steps:
@@ -30,7 +30,7 @@ jobs:
           python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
           cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
       - name: Pre-Release Check - SonarQube Hotspots
-        if: always()
+        ${{ always() }}
         env:
           SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}
           SONARQUBE_QUERY_TOKEN: ${{ secrets.SONARQUBE_QUERY_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
           python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
           cd ./.github/workflows/release_scripts/  && python3.8 sonarqube_vulnurability_checker.py
       - name: Pre-Release Check - Prisma vulnurabilities
-        if: always()
+        ${{ always() }}
         env:
           PRISMA_ROOT_API_URL: ${{ secrets.PRISMA_ROOT_API_URL }}
           DOCKER_IMAGE_TO_CHECK: ${{ secrets.PRISMA_DOCKER_IMAGE_TO_CHECK }}

--- a/.github/workflows/release-readiness-check.yaml
+++ b/.github/workflows/release-readiness-check.yaml
@@ -1,0 +1,52 @@
+name: Release Readiness Checks
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          cache: 'pip'
+      - name: Pre-Release Check - Whitesource vulnurabilities
+        env:
+          WS_APIKEY: ${{ secrets.WHITESOURCE_API_KEY }}
+          WS_PROJECTTOKEN: ${{ secrets.WHITESOURCE_PROJECT_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+        run: |
+          pip install --quiet --upgrade pip
+          export VIRTUAL_ENV=./venv
+          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+          cd ./.github/workflows/release_scripts/  && pip install --quiet -r requirements.txt && python3.8 whitesource_vulnurability_checker.py
+      - name: Pre-Release Check - SonarQube Hotspots
+        if: always()
+        env:
+          SONARQUBE_HOTSPOTS_API_URL: ${{ secrets.SONARQUBE_HOTSPOTS_API_URL }}
+          SONARQUBE_QUERY_TOKEN: ${{ secrets.SONARQUBE_QUERY_TOKEN }}
+        run: |
+          export VIRTUAL_ENV=./venv
+          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+          cd ./.github/workflows/release_scripts/  && python3.8 sonarqube_vulnurability_checker.py
+      - name: Pre-Release Check - Prisma vulnurabilities
+        if: always()
+        env:
+          PRISMA_ROOT_API_URL: ${{ secrets.PRISMA_ROOT_API_URL }}
+          DOCKER_IMAGE_TO_CHECK: ${{ secrets.PRISMA_DOCKER_IMAGE_TO_CHECK }}
+          PRISMA_ACCESS_KEY: ${{ secrets.PRISMA_ACCESS_KEY }}
+          PRISMA_ACCESS_KEY_SECRET: ${{ secrets.PRISMA_ACCESS_KEY_SECRET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.EMA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.EMA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.EMA_AWS_DEFAULT_REGION }}
+        run: |
+          export VIRTUAL_ENV=./venv
+          python3.8 -m venv $VIRTUAL_ENV && source $VIRTUAL_ENV/bin/activate
+          cd ./.github/workflows/release_scripts/  && python3.8 prisma_vulnurability_checker.py          

--- a/.github/workflows/release-readiness-check.yaml
+++ b/.github/workflows/release-readiness-check.yaml
@@ -2,7 +2,7 @@ name: Release Readiness Checks
 on:
   push:
     branches:
-      - main
+      - add_workflow_check_prisma_ws
 
 jobs:
   release:


### PR DESCRIPTION
### What is the purpose of this change?
Adding a workflow to run pre-release checks

### How was this change implemented?
Workflow added called `Release Readiness Checks` which checks
- Whitsource
- Prisma
- SonarQube Hotspots
of the repo

This can be executed prior to release to make sure these is ot critical/high vulnerability before release.


### How was this change tested?
https://github.com/SolaceLabs/event-management-agent/actions/runs/5660790076/job/15337277701