### PR TITLE
Fix aws third party fasterxml jackson core vulnerability

### DIFF
--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -84,6 +84,11 @@
             <version>2.15.2</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>third-party-jackson-core</artifactId>
+            <version>2.20.109</version>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.msk</groupId>
             <artifactId>aws-msk-iam-auth</artifactId>
             <version>${aws-msk-iam-auth.version}</version>


### PR DESCRIPTION
### What is the purpose of this change?

To fix the aws third party fasterxml jackson core vulnerability

### How was this change implemented?

By updating the `third-party-jackson-core` artifact.

### How was this change tested?

By starting the EMA and running scans against Kafka and Solace event brokers. Also, testing scans in standalone mode and manual imports.

### Is there anything the reviewers should focus on/be aware of?

N/A
