### PR TITLE
DATAGO-59386: Fix NPE when calling api/v2/ema/scan REST API

### DIFF
--- a/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanService.java
+++ b/service/application/src/main/java/com/solace/maas/ep/event/management/agent/service/ScanService.java
@@ -12,10 +12,12 @@ import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanDesti
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanRecipientEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanRecipientHierarchyEntity;
+import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanStatusEntity;
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanTypeEntity;
 import com.solace.maas.ep.event.management.agent.repository.scan.ScanRecipientHierarchyRepository;
 import com.solace.maas.ep.event.management.agent.repository.scan.ScanRepository;
 import com.solace.maas.ep.event.management.agent.repository.scan.ScanTypeRepository;
+import com.solace.maas.ep.event.management.agent.repository.scan.ScanStatusRepository;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ScanItemBO;
 import com.solace.maas.ep.event.management.agent.scanManager.model.ScanTypeBO;
 import com.solace.maas.ep.event.management.agent.util.IDGenerator;
@@ -50,6 +52,8 @@ public class ScanService {
 
     private final ScanTypeRepository scanTypeRepository;
 
+    private final ScanStatusRepository scanStatusRepository;
+
     private final ScanRouteService scanRouteService;
 
     private final RouteService routeService;
@@ -60,12 +64,13 @@ public class ScanService {
 
     public ScanService(ScanRepository repository,
                        ScanRecipientHierarchyRepository scanRecipientHierarchyRepository,
-                       ScanTypeRepository scanTypeRepository, ScanRouteService scanRouteService,
+                       ScanTypeRepository scanTypeRepository, ScanStatusRepository scanStatusRepository, ScanRouteService scanRouteService,
                        RouteService routeService, ProducerTemplate producerTemplate,
                        IDGenerator idGenerator) {
         this.repository = repository;
         this.scanRecipientHierarchyRepository = scanRecipientHierarchyRepository;
         this.scanTypeRepository = scanTypeRepository;
+        this.scanStatusRepository = scanStatusRepository;
         this.scanRouteService = scanRouteService;
         this.routeService = routeService;
         this.producerTemplate = producerTemplate;
@@ -219,6 +224,8 @@ public class ScanService {
     }
 
     private void setScanType(RouteBundle routeBundle, ScanEntity scanEntity) {
+
+
         ScanTypeEntity scanType = ScanTypeEntity.builder()
                 .id(idGenerator.generateRandomUniqueId())
                 .name(routeBundle.getScanType())
@@ -226,8 +233,20 @@ public class ScanService {
                 .build();
 
         scanTypeRepository.save(scanType);
+
+        setScanStatus(scanType);
     }
 
+    private void setScanStatus(ScanTypeEntity scanType) {
+        ScanStatusEntity scanStatus = ScanStatusEntity.builder()
+                .id(idGenerator.generateRandomUniqueId())
+                .status(ScanStatus.INITIATED.name())
+                .scanType(scanType)
+                .build();
+
+        scanStatusRepository.save(scanStatus);
+
+    }
     protected void setupRecipientsForScan(ScanEntity scanEntity, RouteBundle routeBundle) {
 
         for (RouteBundle recipient : routeBundle.getRecipients()) {

--- a/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ScanServiceTests.java
+++ b/service/application/src/test/java/com/solace/maas/ep/event/management/agent/service/ScanServiceTests.java
@@ -14,6 +14,7 @@ import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanStatu
 import com.solace.maas.ep.event.management.agent.repository.model.scan.ScanTypeEntity;
 import com.solace.maas.ep.event.management.agent.repository.scan.ScanRecipientHierarchyRepository;
 import com.solace.maas.ep.event.management.agent.repository.scan.ScanRepository;
+import com.solace.maas.ep.event.management.agent.repository.scan.ScanStatusRepository;
 import com.solace.maas.ep.event.management.agent.repository.scan.ScanTypeRepository;
 import com.solace.maas.ep.event.management.agent.service.logging.LoggingService;
 import com.solace.maas.ep.event.management.agent.util.IDGenerator;
@@ -23,6 +24,7 @@ import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,9 +43,12 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 @ActiveProfiles("TEST")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = TestConfig.class)
@@ -62,6 +67,9 @@ public class ScanServiceTests {
 
     @Mock
     private ScanTypeRepository scanTypeRepository;
+
+    @Mock
+    private ScanStatusRepository scanStatusRepository;
 
     @Mock
     private ScanRecipientHierarchyRepository scanRecipientHierarchyRepository;
@@ -115,6 +123,7 @@ public class ScanServiceTests {
         RouteEntity returnedEntity = scanServiceHelper.buildRouteEntity(routeId, "", true);
         ScanEntity scanEntity = scanServiceHelper.buildScanEntity("123", "emaId1", List.of(returnedEntity), null);
         ScanTypeEntity scanType = scanServiceHelper.buildScanTypeEntity("scan1", "scanType", scanEntity, null);
+        ScanStatusEntity scanStatus = scanServiceHelper.buildScanStatusEntity("scanstatus1", "dummyStatus");
 
         when(idGenerator.generateRandomUniqueId())
                 .thenReturn("abc123");
@@ -132,6 +141,9 @@ public class ScanServiceTests {
                 .thenReturn(scanEntity);
         when(scanTypeRepository.save(scanType))
                 .thenReturn(scanType);
+        when(scanStatusRepository.save(scanStatus))
+                .thenReturn(scanStatus);
+
         when(scanRecipientHierarchyRepository.save(any(ScanRecipientHierarchyEntity.class)))
                 .thenReturn(mock(ScanRecipientHierarchyEntity.class));
 
@@ -141,6 +153,12 @@ public class ScanServiceTests {
                 "traceId",
                 mock(MessagingServiceEntity.class),
                 "runtimeAgent1");
+
+        ArgumentCaptor<ScanStatusEntity> scanCaptor = ArgumentCaptor.forClass(ScanStatusEntity.class);
+        verify(scanStatusRepository, times(8)).save(scanCaptor.capture());
+
+        // Assert that the scanStatus is initialized to "INITIATED" for all scan types
+        scanCaptor.getAllValues().stream().forEach(entity -> assertThat(entity.getStatus().equals(ScanStatus.INITIATED.name())));
 
         assertThatNoException();
     }
@@ -293,7 +311,7 @@ public class ScanServiceTests {
     public void testSendScanStatus() {
         ScanService service = new ScanService(mock(ScanRepository.class), mock(ScanRecipientHierarchyRepository.class),
                 mock(ScanTypeRepository.class),
-                mock(ScanRouteService.class), mock(RouteService.class), template, idGenerator);
+                mock(ScanStatusRepository.class), mock(ScanRouteService.class), mock(RouteService.class), template, idGenerator);
         service.sendScanStatus("scanId", "groupId", "messagingServiceId", "traceId",
                 "queueListing", ScanStatus.IN_PROGRESS);
 


### PR DESCRIPTION
### What is the purpose of this change?
When a scan has been recently initiated, calling the api/v2/ema/scan API would result in a NPE

### How was this change implemented?
When a scan is started, the scan status was not initialized. This fix initializes the scan status for each scan type to INITIATED.

### How was this change tested?
Manual tested by initiating a scan and calling the scan API directly afterwards.
Also added an automated test that asserts the scan type is initialized as expected.

### Is there anything the reviewers should focus on/be aware of?
No
