### PR TITLE
DATAGO-61135: Update kafka-spring to remove vulnerability

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -18,7 +18,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <spring-cloud-starter-sleuth.version>3.1.5</spring-cloud-starter-sleuth.version>
         <spring-security-rsa.version>1.1.1</spring-security-rsa.version>
-        <spring-kafka.version>3.0.9</spring-kafka.version>
+        <spring-kafka.version>3.0.10</spring-kafka.version>
         <kafka-clients.version>3.5.0</kafka-clients.version>
     </properties>
     <repositories>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <spring-kafka.version>3.0.9</spring-kafka.version>
+        <spring-kafka.version>3.0.10</spring-kafka.version>
         <kafka-clients.version>3.5.0</kafka-clients.version>
         <spring-boot-starter-test.version>3.1.2</spring-boot-starter-test.version>
         <commons-collections4.vresion>4.4</commons-collections4.vresion>


### PR DESCRIPTION
### What is the purpose of this change?

spring-kafka:3.0.9 has a critical vulnerability

### How was this change implemented?

upgrade to spring-kafka:3.0.10

### How was this change tested?

Manually scan of kafka broker

### Is there anything the reviewers should focus on/be aware of?

No
