### PR TITLE
DATAGO-61733: Add missing dependency for SpringBoot 3.x swagger

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>10.1.11</version>
+            <version>10.1.13</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>10.1.13</version>
+            <version>10.1.11</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -51,6 +51,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
### What is the purpose of this change?

With the move to Springboot 3.x, swagger stopped working.

### How was this change implemented?

An additional dependency is required for swagger in Springboot 3.x. That dependency was added to the pom file.

### How was this change tested?

Manually tested. Including a quick regression.

### Is there anything the reviewers should focus on/be aware of?

No.
