### PR TITLE
upgrade the version of org xerial snappy dependency

### DIFF
--- a/service/application/pom.xml
+++ b/service/application/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.10.1</version>
+            <version>1.1.10.5</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/service/kafka-plugin/pom.xml
+++ b/service/kafka-plugin/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.10.1</version>
+            <version>1.1.10.5</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
### What is the purpose of this change?

To fix the `org.xerial.snappy:snappy-java` vulnerability

### How was this change implemented?

 By updating the `snappy-java` artifact.

### How was this change tested?

By starting the EMA and running scans against Kafka and Solace event brokers. Also, testing scans in standalone mode and manual imports.

### Is there anything the reviewers should focus on/be aware of?

N/A
